### PR TITLE
Refactor `AbstractBlockElement` and `Block` classes to use `HasTagName` trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Enh #1: Initial commit (@terabytesoftw)
 - Bug #2: Update docs `Block.md` (@terabytesoftw)
 - Enh #3: Update `ui-awesome/html-attribute`, `ui-awesome/html-concern`, `ui-awesome/html-helper` to `0.2` (@terabytesoftw)
+- Bug #4: Refactor `AbstractBlockElement` and `Block` classes to use `HasTagName` trait (@terabytesoftw)

--- a/src/Base/AbstractBlockElement.php
+++ b/src/Base/AbstractBlockElement.php
@@ -14,7 +14,6 @@ use UIAwesome\Html\{
     Attribute\HasTitle,
     Concern\HasAttributes,
     Concern\HasContent,
-    Concern\HasTagName,
     Core\HTMLBuilder,
     Interop\RenderInterface
 };
@@ -31,8 +30,9 @@ abstract class AbstractBlockElement extends Block implements RenderInterface
     use HasId;
     use HasLang;
     use HasStyle;
-    use HasTagName;
     use HasTitle;
+
+    protected string $tagName = '';
 
     /**
      * Begin rendering the block element.

--- a/src/Block.php
+++ b/src/Block.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core;
 
+use UIAwesome\Html\Concern\HasTagName;
+
 /**
  * The `<block>` HTML element represents a generic block-level element.
  *
@@ -23,4 +25,7 @@ namespace UIAwesome\Html\Core;
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
  */
-final class Block extends Base\AbstractBlockElement {}
+final class Block extends Base\AbstractBlockElement
+{
+    use HasTagName;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
