### PR TITLE
feat(attribute): Enhance `addAttribute()` and `removeAttribute()` methods to support enum keys and improve handling of attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bug #11: Enhance `DataProvider` class documentation and add comprehensive test cases for HTML `data-*` attributes (@terabytesoftw)
 - Bug #12: Update `removeDataAttribute()` method documentation to include example with enum key (@terabytesoftw)
 - Bug #13: Correct documentation formatting for key features across multiple attribute and providers external classes (@terabytesoftw)
+- Enh #14: Enhance `addAttribute()` and `removeAttribute()` methods to support enum keys and improve handling of attributes (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Mixin/HasAttributes.php
+++ b/src/Mixin/HasAttributes.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Mixin;
 
+use InvalidArgumentException;
+use UIAwesome\Html\Core\Exception\Message;
+use UIAwesome\Html\Helper\Enum;
+use UnitEnum;
+
 use function array_merge;
 
 /**
@@ -41,8 +46,8 @@ trait HasAttributes
      *
      * Creates a new instance with the specified attribute, overriding any existing value for that attribute.
      *
-     * @param string $name  Attribute name.
-     * @param mixed  $value Attribute value.
+     * @param string|UnitEnum $key  Attribute name.
+     * @param mixed $value Attribute value.
      *
      * @return static New instance with the updated attribute.
      *
@@ -50,12 +55,33 @@ trait HasAttributes
      * ```php
      * // sets a single attribute
      * $element->addAttribute('id', 'my-id');
+     *
+     * // sets single attribute with an enum key
+     * $element->addAttribute(DataProperty::ID, 'my-id');
+     *
+     * // sets single attribute with an enum value
+     * $element->addAttribute('size', ButtonSize::SMALL);
+     *
+     * // removes attribute
+     * $element->addAttribute('id', null);
      * ```
      */
-    public function addAttribute(string $name, mixed $value): static
+    public function addAttribute(string|UnitEnum $key, mixed $value): static
     {
+        $normalizedKey = Enum::normalizeValue($key);
+
+        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
+            throw new InvalidArgumentException(
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
+            );
+        }
+
+        if ($value === null) {
+            return $this->removeAttribute($normalizedKey);
+        }
+
         $new = clone $this;
-        $new->attributes[$name] = $value;
+        $new->attributes[$normalizedKey] = $value;
 
         return $new;
     }
@@ -76,6 +102,9 @@ trait HasAttributes
      * ```php
      * // sets multiple attributes
      * $element->attributes(['id' => 'my-id', 'data-role' => 'button']);
+     *
+     * // sets multiple attributes with an enum value
+     * $element->attributes(['size' => ButtonSize::LARGE, 'disabled' => true]);
      * ```
      */
     public function attributes(array $values): static
@@ -108,20 +137,25 @@ trait HasAttributes
      *
      * Creates a new instance without the specified attribute.
      *
-     * @param string $name Attribute name to remove.
+     * @param string|UnitEnum $key Attribute name to remove.
      *
      * @return static New instance without the specified attribute.
      *
      * Usage example:
      * ```php
-     * // removes a single attribute
+     * // removes attribute
      * $element->removeAttribute('id');
+     *
+     * // removes attribute with an enum key
+     * $element->removeAttribute(DataProperty::ID);
      * ```
      */
-    public function removeAttribute(string $name): static
+    public function removeAttribute(string|UnitEnum $key): static
     {
+        $normalizedKey = Enum::normalizeValue($key);
+
         $new = clone $this;
-        unset($new->attributes[$name]);
+        unset($new->attributes[$normalizedKey]);
 
         return $new;
     }

--- a/tests/Mixin/HasAttributesTest.php
+++ b/tests/Mixin/HasAttributesTest.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Mixin;
 
 use Closure;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Mixin\AttributeProvider;
+use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
 
 /**
  * Test suite for {@see HasAttributes} mixin functionality and behavior.
@@ -126,5 +129,33 @@ final class HasAttributesTest extends TestCase
             $instance->getAttributes(),
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSetSingleAttributeWithEmptyKey(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
+        );
+
+        $instance->addAttribute('', 'value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSetSingleAttributeWithInvalidKey(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(2),
+        );
+
+        $instance->addAttribute(Priority::HIGH, 'value');
     }
 }

--- a/tests/Mixin/HasAttributesTest.php
+++ b/tests/Mixin/HasAttributesTest.php
@@ -89,7 +89,7 @@ final class HasAttributesTest extends TestCase
 
     /**
      * @param mixed[] $attributes
-     * @param array<string, string|Closure(): mixed> $expected
+     * @param array<string, Closure(): mixed|string> $expected
      */
     #[DataProviderExternal(AttributeProvider::class, 'values')]
     public function testSetAttributesValue(array $attributes, array $expected, string $message): void

--- a/tests/Mixin/HasAttributesTest.php
+++ b/tests/Mixin/HasAttributesTest.php
@@ -88,8 +88,8 @@ final class HasAttributesTest extends TestCase
     }
 
     /**
-     * @param array<string, \Closure(): mixed|string> $attributes
-     * @param array<string, \Closure(): mixed|string> $expected
+     * @param mixed[] $attributes
+     * @param array<string, string|Closure(): mixed> $expected
      */
     #[DataProviderExternal(AttributeProvider::class, 'values')]
     public function testSetAttributesValue(array $attributes, array $expected, string $message): void
@@ -108,7 +108,7 @@ final class HasAttributesTest extends TestCase
     }
 
     /**
-     * @phpstan-param scalar|Closure(): mixed|null $value
+     * @phpstan-param scalar|null|Closure(): mixed $value
      * @phpstan-param mixed[] $expected
      */
     #[DataProviderExternal(AttributeProvider::class, 'value')]

--- a/tests/Mixin/HasAttributesTest.php
+++ b/tests/Mixin/HasAttributesTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Mixin;
 
-use PHPUnit\Framework\Attributes\Group;
+use Closure;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Core\Tests\Support\Provider\Mixin\AttributeProvider;
 
 /**
  * Test suite for {@see HasAttributes} mixin functionality and behavior.
@@ -67,13 +69,13 @@ final class HasAttributesTest extends TestCase
 
         self::assertNotSame(
             $instance,
-            $instance->attributes([]),
-            'Should return a new instance when setting the attributes, ensuring immutability.',
+            $instance->addAttribute('key', 'value'),
+            'Should return a new instance when adding an attribute, ensuring immutability.',
         );
         self::assertNotSame(
             $instance,
-            $instance->addAttribute('key', 'value'),
-            'Should return a new instance when adding an attribute, ensuring immutability.',
+            $instance->attributes([]),
+            'Should return a new instance when setting the attributes, ensuring immutability.',
         );
         self::assertNotSame(
             $instance,
@@ -82,34 +84,47 @@ final class HasAttributesTest extends TestCase
         );
     }
 
-    public function testSetAttributesValue(): void
+    /**
+     * @param array<string, \Closure(): mixed|string> $attributes
+     * @param array<string, \Closure(): mixed|string> $expected
+     */
+    #[DataProviderExternal(AttributeProvider::class, 'values')]
+    public function testSetAttributesValue(array $attributes, array $expected, string $message): void
     {
         $instance = new class {
             use HasAttributes;
         };
 
-        $instance = $instance->attributes(['class' => 'value']);
-        $instance = $instance->attributes(['disabled' => true]);
+        $instance = $instance->attributes($attributes);
 
         self::assertSame(
-            ['class' => 'value', 'disabled' => true],
+            $expected,
             $instance->getAttributes(),
-            'Should return the attributes value after setting it.',
+            $message,
         );
     }
 
-    public function testSetSingleAttributeValue(): void
-    {
+    /**
+     * @phpstan-param scalar|Closure(): mixed|null $value
+     * @phpstan-param mixed[] $expected
+     */
+    #[DataProviderExternal(AttributeProvider::class, 'value')]
+    public function testSetSingleAttributeValue(
+        string $key,
+        bool|float|int|string|Closure|null $value,
+        array $expected,
+        string $message,
+    ): void {
         $instance = new class {
             use HasAttributes;
         };
 
-        $instance = $instance->addAttribute('id', 'my-id');
+        $instance = $instance->addAttribute($key, $value);
 
         self::assertSame(
-            ['id' => 'my-id'],
+            $expected,
             $instance->getAttributes(),
-            'Should return the single attribute value after setting it.',
+            $message,
         );
     }
 }

--- a/tests/Support/Provider/Mixin/AttributeProvider.php
+++ b/tests/Support/Provider/Mixin/AttributeProvider.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Provider\Mixin;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Core\Tests\Mixin\HasAttributesTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of HTML attributes in tag rendering, ensuring
+ * standards-compliant attribute generation, override behavior, and value propagation.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing attributes, supporting bool, scalar
+ * values, and deferred evaluation via \Closure, to maintain consistent output across different rendering
+ * configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of attributes in HTML element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of bool, string (including empty strings), int, float, \Closure, and `null` handling for attributes,
+ *   including hyphenated keys and unset scenarios.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AttributeProvider
+{
+    /**
+     * Provides test cases for single HTML attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of a single HTML attribute, including string
+     * keys and values provided as scalars, \Closure, and `null`.
+     *
+     * Each test case includes the attribute key, the input value, the expected attributes array, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for single attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string, scalar|\Closure(): mixed|null, mixed[], string}>
+     */
+    public static function value(): array
+    {
+        $closure = static fn(): string => 'my-value';
+
+        return [
+            'boolean false' => [
+                'disabled',
+                false,
+                ['disabled' => false],
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                'disabled',
+                true,
+                ['disabled' => true],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure' => [
+                'id',
+                $closure,
+                ['id' => $closure],
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                'class',
+                '',
+                ['class' => ''],
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                'tabindex',
+                0.42,
+                ['tabindex' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'hyphenated key' => [
+                'aria-label',
+                'value',
+                ['aria-label' => 'value'],
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                'tabindex',
+                0,
+                ['tabindex' => 0],
+                'Should return the attribute value after setting it.',
+            ],
+            'string' => [
+                'id',
+                'my-id',
+                ['id' => 'my-id'],
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                'class',
+                null,
+                [],
+                "Should unset the 'class' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for HTML attribute value map scenarios.
+     *
+     * Supplies test data for validating bulk assignment, normalization, and removal of HTML attributes, ensuring
+     * consistent key handling, hyphenated key support, and value propagation for scalars, \Closure, and `null`.
+     *
+     * Each test case includes the input values map, the expected normalized attributes array, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for attribute value map scenarios.
+     *
+     * @phpstan-return array<
+     *   string,
+     *   array{array<string, scalar|\Closure(): mixed|null>, array<string, scalar|\Closure(): mixed|null>, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $closure = static fn(): string => 'my-value';
+
+        return [
+            'boolean false' => [
+                ['disabled' => false],
+                ['disabled' => false],
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                ['disabled' => true],
+                ['disabled' => true],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure' => [
+                ['id' => $closure],
+                ['id' => $closure],
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                ['class' => ''],
+                ['class' => ''],
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                ['tabindex' => 0.42],
+                ['tabindex' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'hyphenated key' => [
+                ['aria-label' => 'value'],
+                ['aria-label' => 'value'],
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                ['tabindex' => 0],
+                ['tabindex' => 0],
+                'Should return the attribute value after setting it.',
+            ],
+            'mixed string and closure' => [
+                [
+                    'id' => 'my-id',
+                    'class' => $closure,
+                ],
+                [
+                    'id' => 'my-id',
+                    'class' => $closure,
+                ],
+                'Should set multiple attributes with mixed string and closure values.',
+            ],
+            'multiple attributes' => [
+                [
+                    'id' => 'my-id',
+                    'class' => 'my-class',
+                    'disabled' => true,
+                ],
+                [
+                    'id' => 'my-id',
+                    'class' => 'my-class',
+                    'disabled' => true,
+                ],
+                'Should set multiple attributes with various value types.',
+            ],
+            'multiple string' => [
+                [
+                    'id' => 'my-id',
+                    'class' => 'my-class',
+                    'title' => 'my-title',
+                ],
+                [
+                    'id' => 'my-id',
+                    'class' => 'my-class',
+                    'title' => 'my-title',
+                ],
+                'Should set multiple attributes with string values.',
+            ],
+            'string' => [
+                ['id' => 'my-id'],
+                ['id' => 'my-id'],
+                'Should return the attribute value after setting it.',
+            ],
+            'null value' => [
+                [
+                    'class' => null,
+                ],
+                [
+                    'class' => null,
+                ],
+                "Should preserve 'null' value when set explicitly.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/Mixin/AttributeProvider.php
+++ b/tests/Support/Provider/Mixin/AttributeProvider.php
@@ -114,10 +114,7 @@ final class AttributeProvider
      *
      * @return array Test data for attribute value map scenarios.
      *
-     * @phpstan-return array<
-     *   string,
-     *   array{array<string, scalar|\Closure(): mixed|null>, array<string, scalar|\Closure(): mixed|null>, string},
-     * >
+     * @phpstan-return array<string, array{mixed[], mixed[], string}>
      */
     public static function values(): array
     {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute APIs now accept enum-based keys and treat null values as removals, improving attribute flexibility and normalization.

* **Tests**
  * Expanded coverage validating enum-key handling, attribute normalization, immutability, and invalid-key error cases via new data providers.

* **Documentation**
  * Changelog and examples updated to document enum-key support and null-as-remove behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->