### PR TITLE
fix(docs): Update PHPStan annotations in `DataProvider` and `HasDataTest` classes for improved type clarity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bug #12: Update `removeDataAttribute()` method documentation to include example with enum key (@terabytesoftw)
 - Bug #13: Correct documentation formatting for key features across multiple attribute and providers external classes (@terabytesoftw)
 - Enh #14: Enhance `addAttribute()` and `removeAttribute()` methods to support enum keys and improve handling of attributes (@terabytesoftw)
+- Bug 315: Update PHPStan annotations in `DataProvider` and `HasDataTest` classes for improved type clarity (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/tests/Attribute/HasDataTest.php
+++ b/tests/Attribute/HasDataTest.php
@@ -41,7 +41,7 @@ use UnitEnum;
 final class HasDataTest extends TestCase
 {
     /**
-     * @param array<string, \Closure(): mixed|string> $data
+     * @param mixed[] $data
      * @phpstan-param mixed[] $attributes
      */
     #[DataProviderExternal(DataProvider::class, 'renderAttribute')]
@@ -90,8 +90,8 @@ final class HasDataTest extends TestCase
     }
 
     /**
-     * @param array<string, \Closure(): mixed|string> $data
-     * @param array<string, \Closure(): mixed|string> $expected
+     * @param mixed[] $data
+     * @param mixed[] $expected
      */
     #[DataProviderExternal(DataProvider::class, 'values')]
     public function testSetDataAttributeValue(array $data, array $expected, string $message): void
@@ -111,7 +111,7 @@ final class HasDataTest extends TestCase
     }
 
     /**
-     * @phpstan-param scalar|Closure(): mixed|UnitEnum|null $value
+     * @phpstan-param scalar|UnitEnum|null|Closure(): mixed $value
      * @phpstan-param mixed[] $expected
      */
     #[DataProviderExternal(DataProvider::class, 'value')]

--- a/tests/Support/Provider/Attribute/DataProvider.php
+++ b/tests/Support/Provider/Attribute/DataProvider.php
@@ -43,7 +43,7 @@ final class DataProvider
      *
      * @return array Test data for rendered `data-*` attribute scenarios.
      *
-     * @phpstan-return array<string, array{array<string, scalar|\Closure(): mixed|UnitEnum|null>, mixed[], string, string}>
+     * @phpstan-return array<string, array{mixed[], mixed[], string, string}>
      */
     public static function renderAttribute(): array
     {
@@ -190,7 +190,7 @@ final class DataProvider
      *
      * @return array Test data for single `data-*` attribute scenarios.
      *
-     * @phpstan-return array<string, array{string|UnitEnum, scalar|\Closure(): mixed|UnitEnum|null, mixed[], string}>
+     * @phpstan-return array<string, array{string|UnitEnum, scalar|UnitEnum|null|\Closure(): mixed, mixed[], string}>
      */
     public static function value(): array
     {
@@ -266,7 +266,7 @@ final class DataProvider
      *
      * @return array Test data for `data-*` attribute value map scenarios.
      *
-     * @phpstan-return array<string, array{array<string, scalar|\Closure(): mixed|UnitEnum|null>, array<string, scalar|\Closure(): mixed>, string}>
+     * @phpstan-return array<string, array{mixed[], mixed[], string}>
      */
     public static function values(): array
     {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type annotations in test files and data providers for improved static analysis compatibility. No functional changes to the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->