### PR TITLE
fix(tag): Add cases for `<details>`, `<dialog>`, and `<menu>` HTML tags in `Block` enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Enh #14: Enhance `addAttribute()` and `removeAttribute()` methods to support enum keys and improve handling of attributes (@terabytesoftw)
 - Bug #15: Update PHPStan annotations in `DataProvider` and `HasDataTest` classes for improved type clarity (@terabytesoftw)
 - Enh #16: Enhance support for `Stringable` interface types across `HasClass`, `HasData`, `HasStyle`, `HasTitle` and update related tests (@terabytesoftw)
+- Bug #17: Add cases for `<details>`, `<dialog>`, and `<menu>` HTML tags in `Block` enum (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Tag/Block.php
+++ b/src/Tag/Block.php
@@ -89,6 +89,24 @@ enum Block: string
     case DEL = 'del';
 
     /**
+     * Case for the `<details>` HTML tag.
+     *
+     * Categorized as flow and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details
+     */
+    case DETAILS = 'details';
+
+    /**
+     * Case for the `<dialog>` HTML tag.
+     *
+     * Categorized as flow and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog
+     */
+    case DIALOG = 'dialog';
+
+    /**
      * Case for the `<div>` HTML tag.
      *
      * Categorized as flow and palpable content.
@@ -245,6 +263,15 @@ enum Block: string
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main
      */
     case MAIN = 'main';
+
+    /**
+     * Case for the `<menu>` HTML tag.
+     *
+     * Categorized as flow and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/menu
+     */
+    case MENU = 'menu';
 
     /**
      * Case for the `<nav>` HTML tag.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new block-level HTML tags: `<details>`, `<dialog>`, and `<menu>`. These elements are now recognized and handled by the application.

* **Tests**
  * Added test cases to validate the newly supported HTML tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->