### PR TITLE
feat(attribute): Add `HasAccesskey` trait with `accesskey()` method and tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bug #15: Update PHPStan annotations in `DataProvider` and `HasDataTest` classes for improved type clarity (@terabytesoftw)
 - Enh #16: Enhance support for `Stringable` interface types across `HasClass`, `HasData`, `HasStyle`, `HasTitle` and update related tests (@terabytesoftw)
 - Bug #17: Add cases for `<details>`, `<dialog>`, and `<menu>` HTML tags in `Block` enum (@terabytesoftw)
+- Enh #18: Add `HasAccesskey` trait with `accesskey()` method and tests (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Attribute/HasAccesskey.php
+++ b/src/Attribute/HasAccesskey.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Attribute;
+
+/**
+ * Trait for managing the global HTML `accesskey` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `accesskey` attribute on HTML elements, following the
+ * HTML specification for global attributes.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of element access keys,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in tags and components.
+ * - Enforces standards-compliant handling of the HTML `accesskey` global attributes.
+ * - Immutable method for setting or overriding the `accesskey` attribute.
+ * - Supports string and `null` for flexible access key assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey
+ * @property array $attributes HTML attributes array used by the implementing class.
+ * @phpstan-property mixed[] $attributes
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAccesskey
+{
+    /**
+     * Sets the HTML `accesskey` attribute for the element.
+     *
+     * Creates a new instance with the specified access key, supporting both explicit and nullable assignment according
+     * to the HTML specification for global attributes.
+     *
+     * @param string|null $value Access key to set for the element. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `accesskey` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute
+     *
+     * Usage example:
+     * ```php
+     * // sets the `accesskey` attribute to 'k'
+     * $element->accesskey('k');
+     *
+     * // unsets the `accesskey` attribute
+     * $element->accesskey(null);
+     * ```
+     */
+    public function accesskey(string|null $value): static
+    {
+        $new = clone $this;
+
+        if ($value === null) {
+            unset($new->attributes['accesskey']);
+        } else {
+            $new->attributes['accesskey'] = $value;
+        }
+
+        return $new;
+    }
+}

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -7,6 +7,7 @@ namespace UIAwesome\Html\Core\Element;
 use UIAwesome\Html\Core\Attribute\{
     CanBeAutofocus,
     CanBeHidden,
+    HasAccesskey,
     HasClass,
     HasContentEditable,
     HasData,
@@ -56,6 +57,7 @@ abstract class BaseBlock extends BaseTag
 {
     use CanBeAutofocus;
     use CanBeHidden;
+    use HasAccesskey;
     use HasAttributes;
     use HasClass;
     use HasContent;

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -5,7 +5,17 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Element;
 
 use Stringable;
-use UIAwesome\Html\Core\Attribute\{CanBeHidden, HasClass, HasData, HasDir, HasId, HasLang, HasStyle, HasTitle};
+use UIAwesome\Html\Core\Attribute\{
+    CanBeHidden,
+    HasAccesskey,
+    HasClass,
+    HasData,
+    HasDir,
+    HasId,
+    HasLang,
+    HasStyle,
+    HasTitle,
+};
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Core\Mixin\{HasAttributes, HasContent, HasPrefixCollection, HasSuffixCollection, HasTemplate};
@@ -37,6 +47,7 @@ use UIAwesome\Html\Helper\Template;
 abstract class BaseInline extends BaseTag
 {
     use CanBeHidden;
+    use HasAccesskey;
     use HasAttributes;
     use HasClass;
     use HasContent;

--- a/src/Element/BaseVoid.php
+++ b/src/Element/BaseVoid.php
@@ -4,7 +4,17 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Element;
 
-use UIAwesome\Html\Core\Attribute\{CanBeHidden, HasClass, HasData, HasDir, HasId, HasLang, HasStyle, HasTitle};
+use UIAwesome\Html\Core\Attribute\{
+    CanBeHidden,
+    HasAccesskey,
+    HasClass,
+    HasData,
+    HasDir,
+    HasId,
+    HasLang,
+    HasStyle,
+    HasTitle,
+};
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
@@ -35,6 +45,7 @@ use UIAwesome\Html\Core\Tag\Voids;
 abstract class BaseVoid extends BaseTag
 {
     use CanBeHidden;
+    use HasAccesskey;
     use HasAttributes;
     use HasClass;
     use HasData;

--- a/tests/Attribute/HasAccesskeyTest.php
+++ b/tests/Attribute/HasAccesskeyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Attribute\HasAccesskey;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\AccesskeyProvider;
+use UIAwesome\Html\Helper\Attributes;
+
+/**
+ * Test suite for {@see HasAccesskey} trait functionality and behavior.
+ *
+ * Validates the management of the global HTML `accesskey` attribute according to the HTML Living Standard
+ * specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `accesskey` attribute in tag rendering, supporting both
+ * string and `null` for dynamic identifier assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with the `accesskey` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `accesskey` attribute.
+ * - Proper assignment and overriding of `accesskey` value.
+ *
+ * {@see AccesskeyProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attributes')]
+final class HasAccesskeyTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AccesskeyProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithAccesskeyAttribute(
+        string|null $accesskey,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAccesskey;
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes($attributes)->accesskey($accesskey);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenAccesskeyAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAccesskey;
+            use HasAttributes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAccesskeyAttribute(): void
+    {
+        $instance = new class {
+            use HasAccesskey;
+            use HasAttributes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->accesskey(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AccesskeyProvider::class, 'values')]
+    public function testSetAccesskeyAttributeValue(
+        string|null $accesskey,
+        array $attributes,
+        string|null $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAccesskey;
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes($attributes)->accesskey($accesskey);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['accesskey'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -34,8 +34,8 @@ use function get_class;
  * - Immutability of the API when setting or overriding attributes.
  * - Nested rendering using `begin()` and `end()` methods.
  * - Precedence of user-defined attributes over global defaults.
- * - Proper assignment and overriding of attribute values, including `class`, `id`, `lang`, `style`, `title`, and
- *   `data-*`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
+ *   `lang`, `style`, and `title`.
  * - Stack integrity during nested `begin()` and `end()` calls.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -51,6 +51,18 @@ use function get_class;
 final class TagBlockTest extends TestCase
 {
     use TestSupport;
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div accesskey="k">
+            </div>
+            HTML,
+            TagBlock::tag()->accesskey('k')->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
 
     public function testRenderWithAttributes(): void
     {

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -29,8 +29,8 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Data provider-driven validation for edge cases and expected behaviors.
  * - Immutability of the API when setting or overriding attributes.
  * - Precedence of user-defined attributes over global defaults.
- * - Proper assignment and overriding of attribute values, including `class`, `id`, `lang`, `style`, `title`, and
- *   `data-*`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
+ *   `lang`, `style`, and `title`.
  * - Rendering with prefix and suffix content, with and without tag wrappers.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -46,6 +46,17 @@ use UIAwesome\Html\Core\Values\Direction;
 final class TagInlineTest extends TestCase
 {
     use TestSupport;
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span accesskey="k"></span>
+            HTML,
+            TagInline::tag()->accesskey('k')->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
 
     public function testRenderWithAttributes(): void
     {

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -23,8 +23,8 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Accurate rendering of attributes for the void element.
  * - Application of default providers.
  * - Immutability of the API when setting or overriding attributes.
- * - Proper assignment and overriding of attribute values, including `class`, `id`, `lang`, `style`, `title`, and
- *   `data-*`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
+ *   `lang`, `style`, and `title`.
  *
  * {@see DefaultProvider} for default provider implementation.
  * {@see TagVoid} for element implementation details.
@@ -37,6 +37,17 @@ use UIAwesome\Html\Core\Values\Direction;
 final class TagVoidTest extends TestCase
 {
     use TestSupport;
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr accesskey="k">
+            HTML,
+            TagVoid::tag()->accesskey('k')->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
 
     public function testRenderWithAttributes(): void
     {

--- a/tests/Support/Provider/Attribute/AccesskeyProvider.php
+++ b/tests/Support/Provider/Attribute/AccesskeyProvider.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Provider\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Core\Tests\Attribute\HasAccesskeyTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the global HTML `accesskey` attribute in tag
+ * rendering, ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML
+ * specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and unsetting the `accesskey` attribute,
+ * supporting both explicit string and `null` for attribute removal, to maintain consistent output across different
+ * rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, override, and removal of the `accesskey` attribute in HTML element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of empty string, `null`, and standard string for the `accesskey` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AccesskeyProvider
+{
+    /**
+     * Provides test cases for HTML `accesskey` attribute rendering scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the global HTML `accesskey` attribute,
+     * including empty string, `null`, and standard string.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for `accesskey` attribute rendering scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'key',
+                ['accesskey' => 'old-key'],
+                ' accesskey="key"',
+                "Should return new 'accesskey' after replacing the existing 'accesskey' attribute.",
+            ],
+            'string' => [
+                'key',
+                [],
+                ' accesskey="key"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['accesskey' => 'old-key'],
+                '',
+                "Should unset the 'accesskey' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for HTML `accesskey` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the global HTML `accesskey` attribute,
+     * including empty string, `null`, and standard string.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `accesskey` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'key',
+                ['accesskey' => 'old-key'],
+                'key',
+                "Should return new 'accesskey' after replacing the existing 'accesskey' attribute.",
+            ],
+            'string' => [
+                'key',
+                [],
+                'key',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['accesskey' => 'old-key'],
+                '',
+                "Should unset the 'accesskey' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML accesskey attribute support across block, inline, and void elements.

* **Tests**
  * Added comprehensive test coverage and data providers for accesskey attribute functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->