### PR TITLE
feat(attribute): Add `HasTranslate` trait with `translate()` method and tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Enh #16: Enhance support for `Stringable` interface types across `HasClass`, `HasData`, `HasStyle`, `HasTitle` and update related tests (@terabytesoftw)
 - Bug #17: Add cases for `<details>`, `<dialog>`, and `<menu>` HTML tags in `Block` enum (@terabytesoftw)
 - Enh #18: Add `HasAccesskey` trait with `accesskey()` method and tests (@terabytesoftw)
+- Enh #19: Add `HasTranslate` trait with `translate()` method and tests (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Attribute/HasTranslate.php
+++ b/src/Attribute/HasTranslate.php
@@ -42,7 +42,7 @@ trait HasTranslate
      * Creates a new instance with the specified translate, supporting both explicit and nullable assignment according
      * to the HTML specification for global attributes.
      *
-     * @param bool|UnitEnum|string|null $value Translate to set for the element. Can be `null` to unset the attribute.
+     * @param bool|string|UnitEnum|null $value Translate to set for the element. Can be `null` to unset the attribute.
      *
      * @throws InvalidArgumentException if the provided value is not valid.
      *

--- a/src/Attribute/HasTranslate.php
+++ b/src/Attribute/HasTranslate.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Core\Values\Translate;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+use function is_bool;
+
+/**
+ * Trait for managing the global HTML `translate` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `translate` attribute on HTML elements, following the
+ * HTML specification for global attributes.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of element translate
+ * behavior, ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in tags and components.
+ * - Enforces standards-compliant handling of the HTML `translate` global attribute.
+ * - Immutable method for setting or overriding the `translate` attribute.
+ * - Supports bool, string, UnitEnum, and `null` for flexible translate assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate
+ * @property array $attributes HTML attributes array used by the implementing class.
+ * @phpstan-property mixed[] $attributes
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasTranslate
+{
+    /**
+     * Sets the HTML `translate` attribute for the element.
+     *
+     * Creates a new instance with the specified translate, supporting both explicit and nullable assignment according
+     * to the HTML specification for global attributes.
+     *
+     * @param bool|UnitEnum|string|null $value Translate to set for the element. Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `translate` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/interaction.html#attr-translate
+     * {@see Translate} for predefined enum values.
+     *
+     * Usage example:
+     * ```php
+     * // sets the `translate` attribute to `no`
+     * $element->translate(false);
+     *
+     * // sets the `translate` attribute to `yes`
+     * $element->translate(Translate::YES);
+     * ```
+     */
+    public function translate(bool|string|UnitEnum|null $value): static
+    {
+        $new = clone $this;
+
+        if ($value === null) {
+            unset($new->attributes['translate']);
+
+            return $new;
+        }
+
+        if (is_bool($value)) {
+            $value = $value ? 'yes' : 'no';
+        }
+
+        if ($value === 'true') {
+            $value = 'yes';
+        } elseif ($value === 'false') {
+            $value = 'no';
+        }
+
+        Validator::oneOf($value, Translate::cases(), 'translate');
+
+        $new->attributes['translate'] = $value;
+
+        return $new;
+    }
+}

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -20,6 +20,7 @@ use UIAwesome\Html\Core\Attribute\{
     HasStyle,
     HasTabindex,
     HasTitle,
+    HasTranslate,
 };
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
@@ -72,6 +73,7 @@ abstract class BaseBlock extends BaseTag
     use HasStyle;
     use HasTabindex;
     use HasTitle;
+    use HasTranslate;
 
     /**
      * Returns the tag instance representing the block element.

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -15,6 +15,7 @@ use UIAwesome\Html\Core\Attribute\{
     HasLang,
     HasStyle,
     HasTitle,
+    HasTranslate,
 };
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
@@ -60,6 +61,7 @@ abstract class BaseInline extends BaseTag
     use HasSuffixCollection;
     use HasTemplate;
     use HasTitle;
+    use HasTranslate;
 
     /**
      * Returns the tag instance representing the inline element.

--- a/src/Element/BaseVoid.php
+++ b/src/Element/BaseVoid.php
@@ -14,6 +14,7 @@ use UIAwesome\Html\Core\Attribute\{
     HasLang,
     HasStyle,
     HasTitle,
+    HasTranslate,
 };
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
@@ -54,6 +55,7 @@ abstract class BaseVoid extends BaseTag
     use HasLang;
     use HasStyle;
     use HasTitle;
+    use HasTranslate;
 
     /**
      * Returns the tag instance representing the void element.

--- a/src/Values/Translate.php
+++ b/src/Values/Translate.php
@@ -26,14 +26,14 @@ enum Translate: string
     /**
      * Indicates that the element is not translatable (`no`).
      *
-     * The element cannot be translated by the user.
+     * Indicates that the element should not be translated by translation tools.
      */
     case NO = 'no';
 
     /**
      * Indicates that the element is explicitly translatable (`yes`).
      *
-     * The element can be translated by the user.
+     * Indicates that the element should be translated by translation tools.
      */
     case YES = 'yes';
 }

--- a/src/Values/Translate.php
+++ b/src/Values/Translate.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Values;
+
+/**
+ * Represents standardized values for the HTML `translate` global attribute.
+ *
+ * Provides a type-safe, standards-compliant set of translate identifiers for use in element rendering, attributes, and
+ * view helpers, ensuring technical consistency with the HTML specification and modern web standards.
+ *
+ * Key features.
+ * - Designed for use in tags, components, and helpers requiring translate assignment.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Strict mapping of translate values for semantic markup generation and accessibility.
+ * - Values follow the HTML specification for translate: `no` and `yes`.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Translate: string
+{
+    /**
+     * Indicates that the element is not translatable (`no`).
+     *
+     * The element cannot be translated by the user.
+     */
+    case NO = 'no';
+
+    /**
+     * Indicates that the element is explicitly translatable (`yes`).
+     *
+     * The element can be translated by the user.
+     */
+    case YES = 'yes';
+}

--- a/tests/Attribute/HasTranslateTest.php
+++ b/tests/Attribute/HasTranslateTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Attribute;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Core\Attribute\HasTranslate;
+use UIAwesome\Html\Core\Mixin\HasAttributes;
+use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\TranslateProvider;
+use UIAwesome\Html\Core\Values\Translate;
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UnitEnum;
+
+/**
+ * Test suite for {@see HasTranslate} trait functionality and behavior.
+ *
+ * Validates the management of the global HTML `translate` attribute according to the HTML Living Standard
+ * specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `translate` attribute in tag rendering, supporting
+ * bool, string, UnitEnum, and `null` for dynamic translate state assignment.
+ *
+ * Test coverage.
+ * - Accurate rendering of attributes with the `translate` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `translate` attribute.
+ * - Proper assignment and overriding of `translate` value.
+ *
+ * {@see TranslateProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attributes')]
+final class HasTranslateTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(TranslateProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithTranslateAttribute(
+        bool|string|UnitEnum|null $translate,
+        array $attributes,
+        bool|string|UnitEnum $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasTranslate;
+        };
+
+        $instance = $instance->attributes($attributes)->translate($translate);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenTranslateAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTranslate;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingTranslateAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTranslate;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->translate(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(TranslateProvider::class, 'values')]
+    public function testSetTranslateAttributeValue(
+        bool|string|UnitEnum|null $translate,
+        array $attributes,
+        bool|string|UnitEnum $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasTranslate;
+        };
+
+        $instance = $instance->attributes($attributes)->translate($translate);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['translate'] ?? '',
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidTranslateValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTranslate;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                'translate',
+                implode('\', \'', Enum::normalizeArray(Translate::cases())),
+            ),
+        );
+
+        $instance->translate('invalid-value');
+    }
+}

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -35,7 +35,7 @@ use function get_class;
  * - Nested rendering using `begin()` and `end()` methods.
  * - Precedence of user-defined attributes over global defaults.
  * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `style`, and `title`.
+ *   `lang`, `style`, `title`, and `translate`.
  * - Stack integrity during nested `begin()` and `end()` calls.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -423,6 +423,18 @@ final class TagBlockTest extends TestCase
             HTML,
             (string) TagBlock::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div translate="no">
+            </div>
+            HTML,
+            TagBlock::tag()->translate(false)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -30,7 +30,7 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Immutability of the API when setting or overriding attributes.
  * - Precedence of user-defined attributes over global defaults.
  * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `style`, and `title`.
+ *   `lang`, `style`, `title`, and `translate`.
  * - Rendering with prefix and suffix content, with and without tag wrappers.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -405,6 +405,17 @@ final class TagInlineTest extends TestCase
             HTML,
             (string) TagInline::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span translate="no"></span>
+            HTML,
+            TagInline::tag()->translate(false)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -24,7 +24,7 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Application of default providers.
  * - Immutability of the API when setting or overriding attributes.
  * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `style`, and `title`.
+ *   `lang`, `style`, `title`, and `translate`.
  *
  * {@see DefaultProvider} for default provider implementation.
  * {@see TagVoid} for element implementation details.
@@ -180,6 +180,17 @@ final class TagVoidTest extends TestCase
             HTML,
             TagVoid::tag()->title('test-value')->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr translate="no">
+            HTML,
+            TagVoid::tag()->translate(false)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 }

--- a/tests/Support/Provider/Attribute/TranslateProvider.php
+++ b/tests/Support/Provider/Attribute/TranslateProvider.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Provider\Attribute;
+
+use UIAwesome\Html\Core\Tests\Support\EnumDataGenerator;
+use UIAwesome\Html\Core\Values\Translate;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Core\Tests\Attribute\HasTranslateTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the global HTML `translate` attribute in tag
+ * rendering, ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML
+ * specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing the `translate` attribute, supporting
+ * explicit bool, string, UnitEnum, and attribute replacement, to maintain consistent output across different rendering
+ * configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of the `translate` attribute in HTML element
+ *   rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of bool, string, UnitEnum, and `null` for the `translate` attribute, including replacement and unset
+ *   scenarios.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TranslateProvider
+{
+    /**
+     * Provides test cases for rendered HTML `translate` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the global HTML `translate` attribute,
+     * including bool, string, UnitEnum, and replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for rendered `translate` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{bool|string|UnitEnum|null, mixed[], string|UnitEnum, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Translate::class, 'translate', true);
+
+        $staticCase = [
+            'boolean false' => [
+                false,
+                [],
+                ' translate="no"',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                ' translate="yes"',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum replace existing' => [
+                Translate::YES,
+                ['translate' => 'no'],
+                ' translate="yes"',
+                "Should return new 'translate' after replacing the existing 'translate' attribute with enum value.",
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'true',
+                ['translate' => 'no'],
+                ' translate="yes"',
+                "Should return new 'translate' after replacing the existing 'translate' attribute.",
+            ],
+            'string' => [
+                'true',
+                [],
+                ' translate="yes"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string boolean false' => [
+                'false',
+                [],
+                ' translate="no"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string boolean true' => [
+                'true',
+                [],
+                ' translate="yes"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['translate' => 'yes'],
+                '',
+                "Should unset the 'translate' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+
+    /**
+     * Provides test cases for HTML `translate` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the global HTML `translate` attribute,
+     * including bool, string, UnitEnum, and replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `translate` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{bool|string|UnitEnum|null, mixed[], string|UnitEnum, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Translate::class, 'translate', false);
+
+        $staticCase = [
+            'boolean false' => [
+                false,
+                [],
+                'no',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                'yes',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'true',
+                ['translate' => 'no'],
+                'yes',
+                "Should return new 'translate' after replacing the existing 'translate' attribute.",
+            ],
+            'string' => [
+                'true',
+                [],
+                'yes',
+                'Should return the attribute value after setting it.',
+            ],
+            'string boolean false' => [
+                'false',
+                [],
+                'no',
+                'Should return the attribute value after setting it.',
+            ],
+            'string boolean true' => [
+                'true',
+                [],
+                'yes',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['translate' => 'yes'],
+                '',
+                "Should unset the 'translate' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the global HTML translate attribute across block, inline, and void elements.
  * Attribute accepts boolean, string, enum or null inputs and normalizes values to standard "yes"/"no".
  * Immutable API: setting the attribute returns a new instance.

* **Tests**
  * New unit tests covering rendering, normalization, immutability, and validation of translate values.

* **Documentation**
  * Changelog updated with the new translate feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->