### PR TITLE
fix(attribute): Update `draggable` method parameter type to include `UnitEnum` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bug #17: Add cases for `<details>`, `<dialog>`, and `<menu>` HTML tags in `Block` enum (@terabytesoftw)
 - Enh #18: Add `HasAccesskey` trait with `accesskey()` method and tests (@terabytesoftw)
 - Enh #19: Add `HasTranslate` trait with `translate()` method and tests (@terabytesoftw)
+- Bug #20: Update `draggable` method parameter type to include `UnitEnum` class (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Attribute/HasDraggable.php
+++ b/src/Attribute/HasDraggable.php
@@ -42,6 +42,12 @@ trait HasDraggable
      * Creates a new instance with the specified draggable, supporting both explicit and nullable assignment according
      * to the HTML specification for global attributes.
      *
+     * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
+     * MDN-compliant {@see Draggable::cases()} (`true`, `false`) are accepted.
+     *
+     * This allows users to create custom enums with compliant values while preventing browser errors from invalid
+     * attribute values.
+     *
      * @param bool|string|UnitEnum|null $value Draggable to set for the element. Can be `null` to unset
      * the attribute.
      *

--- a/src/Attribute/HasDraggable.php
+++ b/src/Attribute/HasDraggable.php
@@ -7,6 +7,7 @@ namespace UIAwesome\Html\Core\Attribute;
 use InvalidArgumentException;
 use UIAwesome\Html\Core\Values\Draggable;
 use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
 
 use function is_bool;
 
@@ -41,7 +42,7 @@ trait HasDraggable
      * Creates a new instance with the specified draggable, supporting both explicit and nullable assignment according
      * to the HTML specification for global attributes.
      *
-     * @param bool|Draggable|string|null $value Draggable to set for the element. Can be `null` to unset
+     * @param bool|string|UnitEnum|null $value Draggable to set for the element. Can be `null` to unset
      * the attribute.
      *
      * @throws InvalidArgumentException if the provided value is not valid.
@@ -60,7 +61,7 @@ trait HasDraggable
      * $element->draggable(Draggable::TRUE);
      * ```
      */
-    public function draggable(bool|string|Draggable|null $value): static
+    public function draggable(bool|string|UnitEnum|null $value): static
     {
         $new = clone $this;
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated draggable handling to accept enum-based values and validate them against allowed options, improving API compatibility and preventing invalid attribute values.
* **Documentation**
  * Added a changelog entry noting the update and its impact on draggable value handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->