### PR TITLE
fix(docs): Improve PHPDoc for attribute related classes to reflect support for `UnitEnum` types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enh #18: Add `HasAccesskey` trait with `accesskey()` method and tests (@terabytesoftw)
 - Enh #19: Add `HasTranslate` trait with `translate()` method and tests (@terabytesoftw)
 - Bug #20: Update `draggable` method parameter type to include `UnitEnum` class (@terabytesoftw)
+- Bug #21: Improve PHPDoc for attribute related classes to reflect support for `UnitEnum` types (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Attribute/HasContentEditable.php
+++ b/src/Attribute/HasContentEditable.php
@@ -42,6 +42,12 @@ trait HasContentEditable
      * Creates a new instance with the specified content editability, supporting both explicit and nullable assignment
      * according to the HTML specification for global attributes.
      *
+     * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
+     * MDN-compliant {@see ContentEditable::cases()} (`false`, `plaintext-only`, `true`) are accepted.
+     *
+     * This allows users to create custom enums with compliant values while preventing browser errors from invalid
+     * attribute values.
+     *
      * @param bool|string|UnitEnum|null $value Content editability to set for the element. Can be `null` to unset
      * the attribute.
      *

--- a/src/Attribute/HasDir.php
+++ b/src/Attribute/HasDir.php
@@ -40,6 +40,12 @@ trait HasDir
      * Creates a new instance with the specified directionality, supporting both explicit and nullable assignment
      * according to the HTML specification for global attributes.
      *
+     * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
+     * MDN-compliant {@see Direction::cases()} (`auto`, `ltr`, `rtl`) are accepted.
+     *
+     * This allows users to create custom enums with compliant values while preventing browser errors from invalid
+     * attribute values.
+     *
      * @param string|UnitEnum|null $value Directionality to set for the element. Can be `null` to unset the
      * attribute.
      *

--- a/src/Attribute/HasDraggable.php
+++ b/src/Attribute/HasDraggable.php
@@ -43,7 +43,7 @@ trait HasDraggable
      * to the HTML specification for global attributes.
      *
      * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
-     * MDN-compliant {@see Draggable::cases()} (`true`, `false`) are accepted.
+     * MDN-compliant {@see Draggable::cases()} (`false`, `true`) are accepted.
      *
      * This allows users to create custom enums with compliant values while preventing browser errors from invalid
      * attribute values.

--- a/src/Attribute/HasLang.php
+++ b/src/Attribute/HasLang.php
@@ -40,6 +40,12 @@ trait HasLang
      * Creates a new instance with the specified language, supporting both explicit and nullable assignment according to
      * the HTML specification for global attributes.
      *
+     * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
+     * MDN-compliant {@see Language::cases()} are accepted.
+     *
+     * This allows users to create custom enums with compliant values while preventing browser errors from invalid
+     * attribute values.
+     *
      * @param string|UnitEnum|null $value Language to set for the element. Can be `null` to unset the attribute.
      *
      * @throws InvalidArgumentException if the provided value is not valid.

--- a/src/Attribute/HasTranslate.php
+++ b/src/Attribute/HasTranslate.php
@@ -42,6 +42,12 @@ trait HasTranslate
      * Creates a new instance with the specified translate, supporting both explicit and nullable assignment according
      * to the HTML specification for global attributes.
      *
+     * While the method accepts any UnitEnum for flexibility, runtime validation ensures only values matching
+     * MDN-compliant {@see Translate::cases()} (`no`, `yes`) are accepted.
+     *
+     * This allows users to create custom enums with compliant values while preventing browser errors from invalid
+     * attribute values.
+     *
      * @param bool|string|UnitEnum|null $value Translate to set for the element. Can be `null` to unset the attribute.
      *
      * @throws InvalidArgumentException if the provided value is not valid.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced PHPDoc documentation for attribute methods to clarify support for enum types and explain validation behavior for MDN-compliant values. Documentation now details that methods accept flexible enum inputs while runtime validation ensures only approved values are used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->