### PR TITLE
feat(attribute): Add `HasAria` trait with `aria()` method and tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bug #20: Update `draggable` method parameter type to include `UnitEnum` class (@terabytesoftw)
 - Bug #21: Improve PHPDoc for attribute related classes to reflect support for `UnitEnum` types (@terabytesoftw)
 - Enh #22: Add `HasRole` trait with `role()` method and tests (@terabytesoftw)
+- Enh #23: Add `HasAria` trait with `aria()` method and tests (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Attribute/HasAria.php
+++ b/src/Attribute/HasAria.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Attribute;
+
+use Closure;
+use InvalidArgumentException;
+use Stringable;
+use TypeError;
+use UIAwesome\Html\Core\Exception\Message;
+use UIAwesome\Html\Helper\Enum;
+use UnitEnum;
+
+use function gettype;
+use function is_string;
+
+/**
+ * Trait for managing the global HTML `aria-*` attributes in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting custom aria attributes on HTML elements, following the HTML
+ * specification for global attributes.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of `aria-*` attributes,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in tags and components.
+ * - Enforces standards-compliant handling of the HTML `aria-*` global attributes.
+ * - Immutable method for setting or overriding `aria-*` attributes.
+ * - Supports scalar, Closure and UnitEnum for advanced dynamic aria scenarios.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
+ * @property array $attributes HTML attributes array used by the implementing class.
+ * @phpstan-property mixed[] $attributes
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAria
+{
+    /**
+     * Sets a single HTML `aria-*` attribute for the element.
+     *
+     * Creates a new instance with the specified custom aria attribute, supporting scalar, Closure and UnitEnum values
+     * as required by the ARIA specification for global attributes.
+     *
+     * @param string|UnitEnum $key Aria attribute key (without the `aria-` prefix).
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Aria attribute value. Can be `null` to unset
+     * the attribute.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, of incorrect type or format.
+     *
+     * @return static New instance with the updated `aria-*` attribute.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     *
+     * Usage example:
+     * ```php
+     * // sets `aria-pressed` attribute (boolean)
+     * $element->addAriaAttribute('pressed', true);
+     *
+     * // sets `aria-label` attribute (string)
+     * $element->addAriaAttribute('label', 'Close');
+     *
+     * // sets `aria-controls` attribute with a Closure that returns an IDREF
+     * $element->addAriaAttribute('controls', static fn(): string => 'modal-1');
+     *
+     * // sets `aria-autocomplete` attribute with an enum value
+     * $element->addAriaAttribute(Aria::AUTOCOMPLETE, 'list');
+     *
+     * // sets `aria-live` attribute with an enum key
+     * $element->addAriaAttribute(Aria::LIVE, 'polite');
+     *
+     * // sets `aria-describedby` attribute with an enum value
+     * $element->addAriaAttribute(Aria::DESCRIBEDBY, 'description');
+     *
+     * // removes `aria-pressed` attribute
+     * $element->addAriaAttribute('pressed', null);
+     * ```
+     */
+    public function addAriaAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+    ): static {
+        $new = clone $this;
+        $new->addAriaAttributeInternal($key, $value);
+
+        return $new;
+    }
+
+    /**
+     * Sets one or more HTML `aria-*` attributes for the element.
+     *
+     * Creates a new instance with the specified custom aria attributes, supporting both string and Closure as required
+     * by the ARIA and HTML specifications. Enforces standards-compliant key and value types, and throws an exception
+     * for invalid input.
+     *
+     * @param array $values Associative array of aria attribute keys and values. Keys must be string; values must be
+     * scalar, Closure, Stringable, UnitEnum or `null`.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, of incorrect type or format.
+     *
+     * @return static New instance with the updated `aria-*` attributes.
+     *
+     * @link https://html.spec.whatwg.org/#attr-aria-*
+     *
+     * @phpstan-param mixed[] $values
+     *
+     * Usage example:
+     * ```php
+     * // sets multiple aria attributes at once
+     * $element->ariaAttributes(
+     *     [
+     *         'controls' => static fn(): string => 'modal-1',
+     *         'hidden' => false,
+     *         'label' => 'Close',
+     *     ],
+     * );
+     *
+     * // sets `aria-live` attribute with an enum value
+     * $element->ariaAttributes(
+     *     [
+     *         'live' => Live::POLITE,
+     *     ],
+     * );
+     * ```
+     */
+    public function ariaAttributes(array $values): static
+    {
+        $new = clone $this;
+
+        /** @phpstan-var array<string, scalar|Stringable|UnitEnum|Closure(): mixed|null> $values */
+        foreach ($values as $key => $value) {
+            try {
+                $new->addAriaAttributeInternal($key, $value);
+                // @phpstan-ignore catch.neverThrown
+            } catch (TypeError) {
+                throw new InvalidArgumentException(
+                    Message::ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE->getMessage(gettype($value)),
+                );
+            }
+        }
+
+        return $new;
+    }
+
+    /**
+     * Removes a single HTML `aria-*` attribute from the element.
+     *
+     * Creates a new instance with the specified custom aria attribute removed.
+     *
+     * @param string|UnitEnum $key Aria attribute key (without the `aria-` prefix).
+     *
+     * @return static New instance with the specified `aria-*` attribute removed.
+     *
+     * Usage example:
+     * ```php
+     * // removes `aria-pressed` attribute
+     * $element->removeAriaAttribute('pressed');
+     *
+     * // removes `aria-autocomplete` attribute with an enum key
+     * $element->removeAriaAttribute(Aria::AUTOCOMPLETE);
+     * ```
+     */
+    public function removeAriaAttribute(string|UnitEnum $key): static
+    {
+        $normalizedKey = Enum::normalizeValue($key);
+
+        $new = clone $this;
+
+        unset($new->attributes["aria-$normalizedKey"]);
+
+        return $new;
+    }
+
+    /**
+     * Internal method to set a single HTML `aria-*` attribute.
+     *
+     * Modifies the current instance by setting or removing the specified custom aria attribute, supporting scalar,
+     * Closure and UnitEnum values as required by the HTML specification for global attributes.
+     *
+     * @param mixed $key Aria attribute key (without the `aria-` prefix).
+     * @param bool|Closure|float|int|string|UnitEnum|null $value Aria attribute value. Can be `null` to unset the
+     * attribute.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, of incorrect type or format.
+     *
+     * @return static Current instance with the updated `aria-*` attribute.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    private function addAriaAttributeInternal(
+        mixed $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+    ): static {
+        $normalizedKey = Enum::normalizeValue($key);
+
+        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
+            throw new InvalidArgumentException(
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            );
+        }
+
+        if ($value instanceof Closure) {
+            $value = $value();
+        }
+
+        if (is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        if ($value === null) {
+            unset($this->attributes["aria-$normalizedKey"]);
+        } else {
+            $this->attributes["aria-$normalizedKey"] = $value;
+        }
+
+        return $this;
+    }
+}

--- a/src/Attribute/HasData.php
+++ b/src/Attribute/HasData.php
@@ -131,7 +131,7 @@ trait HasData
                 // @phpstan-ignore catch.neverThrown
             } catch (TypeError) {
                 throw new InvalidArgumentException(
-                    Message::DATA_ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE->getMessage(gettype($value)),
+                    Message::ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE->getMessage(gettype($value)),
                 );
             }
         }

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -8,6 +8,7 @@ use UIAwesome\Html\Core\Attribute\{
     CanBeAutofocus,
     CanBeHidden,
     HasAccesskey,
+    HasAria,
     HasClass,
     HasContentEditable,
     HasData,
@@ -60,6 +61,7 @@ abstract class BaseBlock extends BaseTag
     use CanBeAutofocus;
     use CanBeHidden;
     use HasAccesskey;
+    use HasAria;
     use HasAttributes;
     use HasClass;
     use HasContent;

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -8,6 +8,7 @@ use Stringable;
 use UIAwesome\Html\Core\Attribute\{
     CanBeHidden,
     HasAccesskey,
+    HasAria,
     HasClass,
     HasData,
     HasDir,
@@ -50,6 +51,7 @@ abstract class BaseInline extends BaseTag
 {
     use CanBeHidden;
     use HasAccesskey;
+    use HasAria;
     use HasAttributes;
     use HasClass;
     use HasContent;

--- a/src/Element/BaseVoid.php
+++ b/src/Element/BaseVoid.php
@@ -7,6 +7,7 @@ namespace UIAwesome\Html\Core\Element;
 use UIAwesome\Html\Core\Attribute\{
     CanBeHidden,
     HasAccesskey,
+    HasAria,
     HasClass,
     HasData,
     HasDir,
@@ -48,6 +49,7 @@ abstract class BaseVoid extends BaseTag
 {
     use CanBeHidden;
     use HasAccesskey;
+    use HasAria;
     use HasAttributes;
     use HasClass;
     use HasData;

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -32,19 +32,19 @@ use function sprintf;
 enum Message: string
 {
     /**
+     * Error when a attribute value is not a `scalar` or `Closure`.
+     *
+     * Format: "Attribute value must be of type 'scalar' or 'Closure', '%s' given."
+     */
+    case ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE = "Attribute value must be of type 'scalar' or 'Closure'," .
+    "'%s' given.";
+
+    /**
      * Error when attempting to instantiate an abstract class.
      *
      * Format: "Cannot instantiate abstract class '%s' via 'tag()' method."
      */
     case CANNOT_INSTANTIATE_ABSTRACT_CLASS = "Cannot instantiate abstract class '%s' via 'tag()' method.";
-
-    /**
-     * Error when a data attribute value is not a `scalar` or `Closure`.
-     *
-     * Format: "Data attribute value must be of type 'scalar' or 'Closure', '%s' given."
-     */
-    case DATA_ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE = "Data attribute value must be of type 'scalar' or 'Closure'" .
-    ", '%s' given.";
 
     /**
      * Error when an attribute value is invalid.

--- a/src/Values/Aria.php
+++ b/src/Values/Aria.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Values;
+
+/**
+ * Represents standardized ARIA states and properties (attributes) for HTML elements.
+ *
+ * Provides a type-safe, standards-compliant set of `aria-` attribute identifiers for use in element rendering,
+ * attributes, and view helpers, ensuring technical consistency with the WAI-ARIA specification and MDN documentation.
+ *
+ * Key features.
+ * - Designed for use in tags, components, and helpers requiring `aria-` attribute assignment.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Strict mapping of `aria-` attribute names for semantic markup generation and accessibility.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Aria: string
+{
+    /**
+     * `aria-activedescendant` — Identifies the currently active element when focus is on a composite widget.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant
+     */
+    case ACTIVEDESCENDANT = 'activedescendant';
+
+    /**
+     * `aria-atomic` — Indicates whether assistive technologies present all, or only parts of, changed region.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-atomic
+     */
+    case ATOMIC = 'atomic';
+
+    /**
+     * `aria-autocomplete` — Indicates whether input might be automatically completed and how predictions are presented.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-autocomplete
+     */
+    case AUTOCOMPLETE = 'autocomplete';
+
+    /**
+     * `aria-braillelabel` — Defines a string value that labels the current element intended to be converted into Braille.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-braillelabel
+     */
+    case BRAILLELABEL = 'braillelabel';
+
+    /**
+     * `aria-brailleroledescription` — Human-readable, author-localized abbreviated description for role in Braille.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-brailleroledescription
+     */
+    case BRAILLEROLEDESCRIPTION = 'brailleroledescription';
+
+    /**
+     * `aria-busy` — Indicates whether an element is currently being modified.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+     */
+    case BUSY = 'busy';
+
+    /**
+     * `aria-checked` — Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked
+     */
+    case CHECKED = 'checked';
+
+    /**
+     * `aria-colcount` — Defines the total number of columns in a table, grid, or treegrid.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colcount
+     */
+    case COLCOUNT = 'colcount';
+
+    /**
+     * `aria-colindex` — Defines an element's column index within a table, grid, or treegrid.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colindex
+     */
+    case COLINDEX = 'colindex';
+
+    /**
+     * `aria-colindextext` — Human-readable text alternative of the numeric `aria-colindex`.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colindextext
+     */
+    case COLINDEXTEXT = 'colindextext';
+
+    /**
+     * `aria-colspan` — Defines the number of columns spanned by a cell or gridcell.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colspan
+     */
+    case COLSPAN = 'colspan';
+
+    /**
+     * `aria-controls` — Identifies element(s) whose contents or presence are controlled by the element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls
+     */
+    case CONTROLS = 'controls';
+
+    /**
+     * `aria-current` — Indicates that the element represents the current item within a set.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current
+     */
+    case CURRENT = 'current';
+
+    /**
+     * `aria-describedby` — Identifies the element(s) that describes the element on which it is set.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby
+     */
+    case DESCRIBEDBY = 'describedby';
+
+    /**
+     * `aria-description` — Defines a string value that describes or annotates the current element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description
+     */
+    case DESCRIPTION = 'description';
+
+    /**
+     * `aria-details` — Identifies the element(s) that provide additional information related to the object.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details
+     */
+    case DETAILS = 'details';
+
+    /**
+     * `aria-disabled` — Indicates that the element is perceivable but disabled (not editable or operable).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled
+     */
+    case DISABLED = 'disabled';
+
+    /**
+     * `aria-dropeffect` — Indicates what functions may be performed when a dragged object is released.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-dropeffect
+     */
+    case DROPEFFECT = 'dropeffect';
+
+    /**
+     * `aria-errormessage` — Identifies the element(s) that provides an error message for an object.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage
+     */
+    case ERRORMESSAGE = 'errormessage';
+
+    /**
+     * `aria-expanded` — Indicates if a control is expanded or collapsed.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded
+     */
+    case EXPANDED = 'expanded';
+
+    /**
+     * `aria-flowto` — Identifies the next element(s) in an alternate reading order of content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto
+     */
+    case FLOWTO = 'flowto';
+
+    /**
+     * `aria-grabbed` — Indicates an element's "grabbed" state in a drag-and-drop operation.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-grabbed
+     */
+    case GRABBED = 'grabbed';
+
+    /**
+     * `aria-haspopup` — Indicates the availability and type of interactive popup that can be triggered.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup
+     */
+    case HASPOPUP = 'haspopup';
+
+    /**
+     * `aria-hidden` — Indicates whether the element is exposed to an accessibility API.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden
+     */
+    case HIDDEN = 'hidden';
+
+    /**
+     * `aria-invalid` — Indicates that the entered value does not conform to the expected format.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid
+     */
+    case INVALID = 'invalid';
+
+    /**
+     * `aria-keyshortcuts` — Indicates keyboard shortcuts implemented to activate or focus an element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+     */
+    case KEYSHORTCUTS = 'keyshortcuts';
+
+    /**
+     * `aria-label` — Defines a string value that can be used to name an element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label
+     */
+    case LABEL = 'label';
+
+    /**
+     * `aria-labelledby` — Identifies the element(s) that label the element it is applied to.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby
+     */
+    case LABELLEDBY = 'labelledby';
+
+    /**
+     * `aria-level` — Defines the hierarchical level of an element within a structure.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level
+     */
+    case LEVEL = 'level';
+
+    /**
+     * `aria-live` — Indicates that an element will be updated and describes types of updates expected.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live
+     */
+    case LIVE = 'live';
+
+    /**
+     * `aria-modal` — Indicates whether an element is modal when displayed.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-modal
+     */
+    case MODAL = 'modal';
+
+    /**
+     * `aria-multiline` — Indicates whether a textbox accepts multiple lines of input.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-multiline
+     */
+    case MULTILINE = 'multiline';
+
+    /**
+     * `aria-multiselectable` — Indicates that more than one descendant may be selected.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-multiselectable
+     */
+    case MULTISELECTABLE = 'multiselectable';
+
+    /**
+     * `aria-orientation` — Indicates whether the element's orientation is horizontal, vertical, or unknown.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-orientation
+     */
+    case ORIENTATION = 'orientation';
+
+    /**
+     * `aria-owns` — Identifies an element (or elements) to define relationships when DOM hierarchy cannot.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns
+     */
+    case OWNS = 'owns';
+
+    /**
+     * `aria-placeholder` — Defines a short hint intended to help the user with data entry when control has no value.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-placeholder
+     */
+    case PLACEHOLDER = 'placeholder';
+
+    /**
+     * `aria-posinset` — Defines an element's number or position in the current set when not all items present.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-posinset
+     */
+    case POSINSET = 'posinset';
+
+    /**
+     * `aria-pressed` — Indicates the current "pressed" state of a toggle button.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-pressed
+     */
+    case PRESSED = 'pressed';
+
+    /**
+     * `aria-readonly` — Indicates that the element is not editable but otherwise operable.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-readonly
+     */
+    case READONLY = 'readonly';
+
+    /**
+     * `aria-relevant` — Indicates what notifications the user agent will trigger when a live region is modified.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-relevant
+     */
+    case RELEVANT = 'relevant';
+
+    /**
+     * `aria-required` — Indicates that user input is required on the element before form submission.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-required
+     */
+    case REQUIRED = 'required';
+
+    /**
+     * `aria-roledescription` — Defines a human-readable, author-localized description for the role.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-roledescription
+     */
+    case ROLEDESCRIPTION = 'roledescription';
+
+    /**
+     * `aria-rowcount` — Defines the total number of rows in a table, grid, or treegrid.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowcount
+     */
+    case ROWCOUNT = 'rowcount';
+
+    /**
+     * `aria-rowindex` — Defines an element's position with respect to the total number of rows.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowindex
+     */
+    case ROWINDEX = 'rowindex';
+
+    /**
+     * `aria-rowindextext` — Human-readable text alternative of `aria-rowindex`.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowindextext
+     */
+    case ROWINDEXTEXT = 'rowindextext';
+
+    /**
+     * `aria-rowspan` — Defines the number of rows spanned by a cell or gridcell.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowspan
+     */
+    case ROWSPAN = 'rowspan';
+
+    /**
+     * `aria-selected` — Indicates the current "selected" state of various widgets.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-selected
+     */
+    case SELECTED = 'selected';
+
+    /**
+     * `aria-setsize` — Defines the number of items in the current set when not all items are present in the DOM.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-setsize
+     */
+    case SETSIZE = 'setsize';
+
+    /**
+     * `aria-sort` — Indicates if items in a table or grid are sorted in ascending or descending order.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-sort
+     */
+    case SORT = 'sort';
+
+    /**
+     * `aria-valuemax` — Defines the maximum allowed value for a range widget.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemax
+     */
+    case VALUEMAX = 'valuemax';
+
+    /**
+     * `aria-valuemin` — Defines the minimum allowed value for a range widget.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemin
+     */
+    case VALUEMIN = 'valuemin';
+
+    /**
+     * `aria-valuenow` — Defines the current value for a range widget.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow
+     */
+    case VALUENOW = 'valuenow';
+
+    /**
+     * `aria-valuetext` — Defines the human-readable text alternative of `aria-valuenow`.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext
+     */
+    case VALUETEXT = 'valuetext';
+}

--- a/tests/Attribute/HasAriaTest.php
+++ b/tests/Attribute/HasAriaTest.php
@@ -10,43 +10,23 @@ use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Stringable;
-use UIAwesome\Html\Core\Attribute\HasData;
+use UIAwesome\Html\Core\Attribute\HasAria;
 use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
-use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\DataProvider;
+use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\AriaProvider;
 use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
 use UIAwesome\Html\Helper\Attributes;
 use UnitEnum;
 
-/**
- * Test suite for {@see HasData} trait functionality and behavior.
- *
- * Validates the management of the global HTML `data-*` attributes according to the HTML Living Standard specification.
- *
- * Ensures correct handling, immutability, and validation of `data-*` attributes in tag rendering, supporting both
- * string and Closure for dynamic data assignment.
- *
- * Test coverage.
- * - Accurate rendering of attributes with `data-*` attributes.
- * - Data provider-driven validation for edge cases and expected behaviors.
- * - Exception handling for invalid keys and values.
- * - Immutability of the trait's API when setting or overriding `data-*` attributes.
- * - Proper assignment and overriding of `data-*` value.
- *
- * {@see DataProvider} for test case data providers.
- *
- * @copyright Copyright (C) 2025 Terabytesoftw.
- * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
- */
 #[Group('attributes')]
-final class HasDataTest extends TestCase
+final class HasAriaTest extends TestCase
 {
     /**
      * @param mixed[] $data
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(DataProvider::class, 'renderAttribute')]
-    public function testRenderAttributesWithDataAttribute(
+    #[DataProviderExternal(AriaProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithAriaAttribute(
         array $data,
         array $attributes,
         string $expected,
@@ -54,10 +34,10 @@ final class HasDataTest extends TestCase
     ): void {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
-        $instance = $instance->attributes($attributes)->dataAttributes($data);
+        $instance = $instance->attributes($attributes)->ariaAttributes($data);
 
         self::assertSame(
             $expected,
@@ -66,26 +46,26 @@ final class HasDataTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingDataAttribute(): void
+    public function testReturnNewInstanceWhenSettingAriaAttribute(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->addDataAttribute('action', 'test-action'),
+            $instance->addAriaAttribute('pressed', true),
             'Should return a new instance when adding the attribute, ensuring immutability.',
         );
         self::assertNotSame(
             $instance,
-            $instance->dataAttributes(['action' => 'test-action']),
+            $instance->ariaAttributes(['pressed' => true]),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
             $instance,
-            $instance->removeDataAttribute('action'),
+            $instance->removeAriaAttribute('pressed'),
             'Should return a new instance when removing the attribute, ensuring immutability.',
         );
     }
@@ -94,15 +74,15 @@ final class HasDataTest extends TestCase
      * @param mixed[] $data
      * @param mixed[] $expected
      */
-    #[DataProviderExternal(DataProvider::class, 'values')]
-    public function testSetDataAttributeValue(array $data, array $expected, string $message): void
+    #[DataProviderExternal(AriaProvider::class, 'values')]
+    public function testSetAriaAttributeValue(array $data, array $expected, string $message): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
-        $instance = $instance->dataAttributes($data);
+        $instance = $instance->ariaAttributes($data);
 
         self::assertSame(
             $expected,
@@ -115,8 +95,8 @@ final class HasDataTest extends TestCase
      * @phpstan-param scalar|Stringable|UnitEnum|null|Closure(): mixed $value
      * @phpstan-param mixed[] $expected
      */
-    #[DataProviderExternal(DataProvider::class, 'value')]
-    public function testSetSingleDataAttributeValue(
+    #[DataProviderExternal(AriaProvider::class, 'value')]
+    public function testSetSingleAriaAttributeValue(
         string|UnitEnum $key,
         bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
         array $expected,
@@ -124,10 +104,10 @@ final class HasDataTest extends TestCase
     ): void {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
-        $instance = $instance->addDataAttribute($key, $value);
+        $instance = $instance->addAriaAttribute($key, $value);
 
         self::assertSame(
             $expected,
@@ -136,11 +116,11 @@ final class HasDataTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionWhenDataAttributeValueIsInvalid(): void
+    public function testThrowInvalidArgumentExceptionWhenAriaAttributeValueIsInvalid(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -148,14 +128,14 @@ final class HasDataTest extends TestCase
             Message::ATTRIBUTE_VALUE_MUST_BE_SCALAR_OR_CLOSURE->getMessage('object'),
         );
 
-        $instance->dataAttributes(['key' => new stdClass()]);
+        $instance->ariaAttributes(['key' => new stdClass()]);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetDataAttributeKeyIsEmpty(): void
+    public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsEmpty(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -163,14 +143,14 @@ final class HasDataTest extends TestCase
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
         );
 
-        $instance->dataAttributes(['' => 'value']);
+        $instance->ariaAttributes(['' => 'value']);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetDataAttributeKeyIsInvalid(): void
+    public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsInvalid(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -178,14 +158,14 @@ final class HasDataTest extends TestCase
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(1),
         );
 
-        $instance->dataAttributes([1 => '']);
+        $instance->ariaAttributes([1 => '']);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetSingleDataAttributeWithEmptyKey(): void
+    public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithEmptyKey(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -193,14 +173,14 @@ final class HasDataTest extends TestCase
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
         );
 
-        $instance->addDataAttribute('', 'value');
+        $instance->addAriaAttribute('', 'value');
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetSingleDataAttributeWithInvalidKey(): void
+    public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithInvalidKey(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasData;
+            use HasAria;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -208,6 +188,6 @@ final class HasDataTest extends TestCase
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(2),
         );
 
-        $instance->addDataAttribute(Priority::HIGH, 'value');
+        $instance->addAriaAttribute(Priority::HIGH, 'value');
     }
 }

--- a/tests/Attribute/HasAriaTest.php
+++ b/tests/Attribute/HasAriaTest.php
@@ -33,8 +33,8 @@ final class HasAriaTest extends TestCase
         string $message,
     ): void {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $instance = $instance->attributes($attributes)->ariaAttributes($data);
@@ -49,8 +49,8 @@ final class HasAriaTest extends TestCase
     public function testReturnNewInstanceWhenSettingAriaAttribute(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         self::assertNotSame(
@@ -78,8 +78,8 @@ final class HasAriaTest extends TestCase
     public function testSetAriaAttributeValue(array $data, array $expected, string $message): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $instance = $instance->ariaAttributes($data);
@@ -103,8 +103,8 @@ final class HasAriaTest extends TestCase
         string $message,
     ): void {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $instance = $instance->addAriaAttribute($key, $value);
@@ -119,8 +119,8 @@ final class HasAriaTest extends TestCase
     public function testThrowInvalidArgumentExceptionWhenAriaAttributeValueIsInvalid(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -134,8 +134,8 @@ final class HasAriaTest extends TestCase
     public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsEmpty(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -149,8 +149,8 @@ final class HasAriaTest extends TestCase
     public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsInvalid(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -164,8 +164,8 @@ final class HasAriaTest extends TestCase
     public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithEmptyKey(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -179,8 +179,8 @@ final class HasAriaTest extends TestCase
     public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithInvalidKey(): void
     {
         $instance = new class {
-            use HasAttributes;
             use HasAria;
+            use HasAttributes;
         };
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -14,7 +14,7 @@ use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Core\Tag\Block;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagBlock, TagInline};
 use UIAwesome\Html\Core\Tests\Support\TestSupport;
-use UIAwesome\Html\Core\Values\{Aria, ContentEditable, DataProperty, Direction, Draggable};
+use UIAwesome\Html\Core\Values\{Aria, ContentEditable, DataProperty, Direction, Draggable, Language, Role, Translate};
 
 use function get_class;
 
@@ -100,7 +100,7 @@ final class TagBlockTest extends TestCase
         );
     }
 
-    public function testRenderAddDataAttributeUsingEnum(): void
+    public function testRenderWithAddDataAttributeUsingEnum(): void
     {
         self::equalsWithoutLE(
             <<<HTML
@@ -199,8 +199,20 @@ final class TagBlockTest extends TestCase
             <div contenteditable="true">
             </div>
             HTML,
-            TagBlock::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            TagBlock::tag()->contentEditable(true)->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div contenteditable="true">
+            </div>
+            HTML,
+            TagBlock::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
         );
     }
 
@@ -261,8 +273,20 @@ final class TagBlockTest extends TestCase
             <div dir="rtl">
             </div>
             HTML,
-            TagBlock::tag()->dir(Direction::RTL)->render(),
+            TagBlock::tag()->dir('rtl')->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div dir="rtl">
+            </div>
+            HTML,
+            TagBlock::tag()->dir(Direction::RTL)->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
@@ -273,8 +297,20 @@ final class TagBlockTest extends TestCase
             <div draggable="true">
             </div>
             HTML,
-            TagBlock::tag()->draggable(Draggable::TRUE)->render(),
+            TagBlock::tag()->draggable(true)->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div draggable="true">
+            </div>
+            HTML,
+            TagBlock::tag()->draggable(Draggable::TRUE)->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
         );
     }
 
@@ -390,6 +426,18 @@ final class TagBlockTest extends TestCase
         );
     }
 
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div lang="es">
+            </div>
+            HTML,
+            TagBlock::tag()->lang(Language::SPANISH)->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
     public function testRenderWithNestedBeginEnd(): void
     {
         self::equalsWithoutLE(
@@ -429,6 +477,18 @@ final class TagBlockTest extends TestCase
             HTML,
             TagBlock::tag()->role('banner')->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div role="banner">
+            </div>
+            HTML,
+            TagBlock::tag()->role(Role::BANNER)->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
@@ -513,6 +573,18 @@ final class TagBlockTest extends TestCase
             HTML,
             TagBlock::tag()->translate(false)->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div translate="yes">
+            </div>
+            HTML,
+            TagBlock::tag()->translate(Translate::YES)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using boolean.",
         );
     }
 

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -584,7 +584,7 @@ final class TagBlockTest extends TestCase
             </div>
             HTML,
             TagBlock::tag()->translate(Translate::YES)->render(),
-            "Failed asserting that element renders correctly with 'translate' attribute using boolean.",
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -14,7 +14,7 @@ use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Core\Tag\Block;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagBlock, TagInline};
 use UIAwesome\Html\Core\Tests\Support\TestSupport;
-use UIAwesome\Html\Core\Values\{ContentEditable, Direction, Draggable};
+use UIAwesome\Html\Core\Values\{Aria, ContentEditable, DataProperty, Direction, Draggable};
 
 use function get_class;
 
@@ -34,8 +34,8 @@ use function get_class;
  * - Immutability of the API when setting or overriding attributes.
  * - Nested rendering using `begin()` and `end()` methods.
  * - Precedence of user-defined attributes over global defaults.
- * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `role`, `style`, `title`, and `translate`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `aria-*`, `class`, `data-*`, `dir`,
+ *   `id`, `lang`, `role`, `style`, `title`, and `translate`.
  * - Stack integrity during nested `begin()` and `end()` calls.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -61,6 +61,72 @@ final class TagBlockTest extends TestCase
             HTML,
             TagBlock::tag()->accesskey('k')->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div aria-pressed="true">
+            </div>
+            HTML,
+            TagBlock::tag()->addAriaAttribute('pressed', true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div aria-pressed="true">
+            </div>
+            HTML,
+            TagBlock::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div data-value="value">
+            </div>
+            HTML,
+            TagBlock::tag()->addDataAttribute('value', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderAddDataAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div data-value="value">
+            </div>
+            HTML,
+            TagBlock::tag()->addDataAttribute(DataProperty::VALUE, 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <div aria-controls="modal-1" aria-hidden="false" aria-label="Close">
+            </div>
+            HTML,
+            TagBlock::tag()->ariaAttributes(
+                [
+                    'controls' => static fn(): string => 'modal-1',
+                    'hidden' => false,
+                    'label' => 'Close',
+                ],
+            )->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
     }
 

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -58,6 +58,45 @@ final class TagInlineTest extends TestCase
         );
     }
 
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span aria-pressed="true"></span>
+            HTML,
+            TagInline::tag()->addAriaAttribute('pressed', true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span data-value="value"></span>
+            HTML,
+            TagInline::tag()->addDataAttribute('value', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span aria-controls="modal-1" aria-hidden="false" aria-label="Close"></span>
+            HTML,
+            TagInline::tag()->ariaAttributes(
+                [
+                    'controls' => static fn(): string => 'modal-1',
+                    'hidden' => false,
+                    'label' => 'Close',
+                ],
+            )->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
     public function testRenderWithAttributes(): void
     {
         self::equalsWithoutLE(

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -12,7 +12,7 @@ use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Core\Tag\Inline;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagInline};
 use UIAwesome\Html\Core\Tests\Support\TestSupport;
-use UIAwesome\Html\Core\Values\Direction;
+use UIAwesome\Html\Core\Values\{Aria, ContentEditable, DataProperty, Direction, Draggable, Language, Role, Translate};
 
 /**
  * Test suite for {@see TagInline} element functionality and behavior.
@@ -29,8 +29,8 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Data provider-driven validation for edge cases and expected behaviors.
  * - Immutability of the API when setting or overriding attributes.
  * - Precedence of user-defined attributes over global defaults.
- * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `role`, `style`, `title`, and `translate`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `aria-*`, `class`, `data-*`, `dir`,
+ *  `id`, `lang`, `role`, `style`, `title`, and `translate`.
  * - Rendering with prefix and suffix content, with and without tag wrappers.
  *
  * {@see DefaultProvider} for default provider implementation.
@@ -69,6 +69,17 @@ final class TagInlineTest extends TestCase
         );
     }
 
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span aria-pressed="true"></span>
+            HTML,
+            TagInline::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
     public function testRenderWithAddDataAttribute(): void
     {
         self::equalsWithoutLE(
@@ -77,6 +88,17 @@ final class TagInlineTest extends TestCase
             HTML,
             TagInline::tag()->addDataAttribute('value', 'value')->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span data-value="value"></span>
+            HTML,
+            TagInline::tag()->addDataAttribute(DataProperty::VALUE, 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
     }
 
@@ -141,6 +163,17 @@ final class TagInlineTest extends TestCase
         );
     }
 
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span contenteditable="true"></span>
+            HTML,
+            TagInline::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
+        );
+    }
+
     public function testRenderWithDataAttributes(): void
     {
         self::equalsWithoutLE(
@@ -191,10 +224,21 @@ final class TagInlineTest extends TestCase
     {
         self::equalsWithoutLE(
             <<<HTML
-            <span dir="ltr"></span>
+            <span dir="rtl"></span>
             HTML,
-            TagInline::tag()->dir(Direction::LTR)->render(),
+            TagInline::tag()->dir('rtl')->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span dir="rtl"></span>
+            HTML,
+            TagInline::tag()->dir(Direction::RTL)->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
@@ -206,6 +250,17 @@ final class TagInlineTest extends TestCase
             HTML,
             TagInline::tag()->draggable(true)->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span draggable="true"></span>
+            HTML,
+            TagInline::tag()->draggable(Draggable::TRUE)->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
         );
     }
 
@@ -316,6 +371,17 @@ final class TagInlineTest extends TestCase
         );
     }
 
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span lang="es"></span>
+            HTML,
+            TagInline::tag()->lang(Language::SPANISH)->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
     public function testRenderWithPrefixAndSuffix(): void
     {
         self::equalsWithoutLE(
@@ -371,6 +437,17 @@ final class TagInlineTest extends TestCase
             HTML,
             TagInline::tag()->role('button')->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span role="button"></span>
+            HTML,
+            TagInline::tag()->role(Role::BUTTON)->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
@@ -466,6 +543,17 @@ final class TagInlineTest extends TestCase
             HTML,
             TagInline::tag()->translate(false)->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <span translate="no"></span>
+            HTML,
+            TagInline::tag()->translate(Translate::NO)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -49,6 +49,43 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr aria-pressed="true">
+            HTML,
+            TagVoid::tag()->addAriaAttribute('pressed', true)->render(),
+            "Failed asserting that element renders correctly with 'ariaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr data-value="value">
+            HTML,
+            TagVoid::tag()->addDataAttribute('value', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr aria-label="Close" aria-hidden="false" aria-controls="modal-1">
+            HTML,
+            TagVoid::tag()->ariaAttributes([
+                'label' => 'Close',
+                'hidden' => false,
+                'controls' => static fn(): string => 'modal-1',
+            ])->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
     public function testRenderWithAttributes(): void
     {
         self::equalsWithoutLE(

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagVoid};
 use UIAwesome\Html\Core\Tests\Support\TestSupport;
-use UIAwesome\Html\Core\Values\Direction;
+use UIAwesome\Html\Core\Values\{Aria, DataProperty, Direction};
 
 /**
  * Test suite for {@see TagVoid} element functionality and behavior.
@@ -23,8 +23,8 @@ use UIAwesome\Html\Core\Values\Direction;
  * - Accurate rendering of attributes for the void element.
  * - Application of default providers.
  * - Immutability of the API when setting or overriding attributes.
- * - Proper assignment and overriding of attribute values, including `accesskey`, `class`, `data-*`, `dir`, `id`,
- *   `lang`, `role`, `style`, `title`, and `translate`.
+ * - Proper assignment and overriding of attribute values, including `accesskey`, `aria-*`, `class`, `data-*`, `dir`,
+ *   `id`, `lang`, `role`, `style`, `title`, and `translate`.
  *
  * {@see DefaultProvider} for default provider implementation.
  * {@see TagVoid} for element implementation details.
@@ -60,6 +60,17 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr aria-pressed="true">
+            HTML,
+            TagVoid::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
     public function testRenderWithAddDataAttribute(): void
     {
         self::equalsWithoutLE(
@@ -68,6 +79,17 @@ final class TagVoidTest extends TestCase
             HTML,
             TagVoid::tag()->addDataAttribute('value', 'value')->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr data-value="value">
+            HTML,
+            TagVoid::tag()->addDataAttribute(DataProperty::VALUE, 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
     }
 
@@ -160,8 +182,19 @@ final class TagVoidTest extends TestCase
             <<<HTML
             <hr dir="rtl">
             HTML,
-            TagVoid::tag()->dir(Direction::RTL)->render(),
+            TagVoid::tag()->dir('rtl')->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::equalsWithoutLE(
+            <<<HTML
+            <hr dir="ltr">
+            HTML,
+            TagVoid::tag()->dir(Direction::LTR)->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 

--- a/tests/Support/Provider/Attribute/AriaProvider.php
+++ b/tests/Support/Provider/Attribute/AriaProvider.php
@@ -203,7 +203,6 @@ final class AriaProvider
      *
      * @return array Test data for single `aria-*` attribute scenarios.
      *
-     *
      * @phpstan-return array<
      *   string,
      *   array{string|UnitEnum, scalar|Stringable|UnitEnum|null|\Closure(): mixed, mixed[], string},

--- a/tests/Support/Provider/Attribute/AriaProvider.php
+++ b/tests/Support/Provider/Attribute/AriaProvider.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Provider\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Core\Tests\Support\Stub\Enum\ButtonSize;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Core\Tests\Attribute\HasAriaTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of HTML `aria-*` attributes in tag rendering, ensuring
+ * standards-compliant attribute generation, key normalization, override behavior, and value propagation.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing `aria-*` attributes, supporting bool,
+ * scalar, UnitEnum, and deferred evaluation via \Closure, to maintain consistent output across different rendering
+ * configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of `aria-*` attributes in HTML element rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of bool, string (including empty strings), int, float, array, UnitEnum, \Closure, and `null` handling
+ *   for `aria-*` attributes, including hyphenated keys and unset scenarios.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AriaProvider
+{
+    /**
+     * Provides test cases for rendered HTML `aria-*` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of HTML `aria-*` attributes, including
+     * scalar, array rendered as JSON, Stringable, UnitEnum, and \Closure.
+     *
+     * Each test case includes the input value, the initial attributes, the override flag, the expected rendered output,
+     * and an assertion message for clear identification.
+     *
+     * @return array Test data for rendered `aria-*` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{mixed[], mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'boolean false' => [
+                ['pressed' => false],
+                [],
+                ' aria-pressed="false"',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                ['pressed' => true],
+                [],
+                ' aria-pressed="true"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with array' => [
+                ['controls' => static fn(): array => ['key' => 'value']],
+                [],
+                ' aria-controls=' . "'" . '{"key":"value"}' . "'",
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean false' => [
+                ['pressed' => static fn(): bool => false],
+                [],
+                ' aria-pressed="false"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean true' => [
+                ['pressed' => static fn(): bool => true],
+                [],
+                ' aria-pressed="true"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with empty string' => [
+                ['label' => static fn(): string => ''],
+                [],
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with enum' => [
+                ['size' => static fn(): ButtonSize => ButtonSize::SMALL],
+                [],
+                ' aria-size="sm"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with float' => [
+                ['value' => static fn(): float => 0.42],
+                [],
+                ' aria-value="0.42"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with integer' => [
+                ['value' => static fn(): int => 42],
+                [],
+                ' aria-value="42"',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with null' => [
+                ['label' => static fn(): null|string => null],
+                [],
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with string' => [
+                ['label' => static fn(): string => 'Close'],
+                [],
+                ' aria-label="Close"',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                ['label' => ''],
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum value' => [
+                ['size' => ButtonSize::SMALL],
+                [],
+                ' aria-size="sm"',
+                'Should return the attribute value after setting it.',
+            ],
+            'float' => [
+                ['value' => 0.42],
+                [],
+                ' aria-value="0.42"',
+                'Should return the attribute value after setting it.',
+            ],
+            'hyphenated key' => [
+                ['described-by' => 'desc'],
+                [],
+                ' aria-described-by="desc"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                ['value' => 42],
+                [],
+                ' aria-value="42"',
+                'Should return the attribute value after setting it.',
+            ],
+            'mixed string and closure' => [
+                [
+                    'label' => 'Close',
+                    'controls' => static fn(): string => 'modal-1',
+                ],
+                [],
+                ' aria-label="Close" aria-controls="modal-1"',
+                "Should set multiple 'aria' attributes with mixed string and closure values.",
+            ],
+            'multiple string' => [
+                [
+                    'label' => 'Close',
+                    'live' => 'polite',
+                    'value' => 'value',
+                ],
+                [],
+                ' aria-label="Close" aria-live="polite" aria-value="value"',
+                "Should set multiple 'aria' attributes with string values.",
+            ],
+            'string' => [
+                ['label' => 'Close'],
+                [],
+                ' aria-label="Close"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                [
+                    'label' => new class implements Stringable {
+                        public function __toString(): string
+                        {
+                            return 'stringable-value';
+                        }
+                    },
+                ],
+                [],
+                ' aria-label="stringable-value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                ['label' => null],
+                [],
+                '',
+                "Should unset the 'aria-label' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for single HTML `aria-*` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of a single HTML `aria-*` attribute,
+     * including string keys, enum-based keys via UnitEnum, and values provided as scalars, Stringable, UnitEnum,
+     * \Closure, and `null`.
+     *
+     * Each test case includes the attribute key, the input value, the expected attributes array, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for single `aria-*` attribute scenarios.
+     *
+     *
+     * @phpstan-return array<
+     *   string,
+     *   array{string|UnitEnum, scalar|Stringable|UnitEnum|null|\Closure(): mixed, mixed[], string},
+     * >
+     */
+    public static function value(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+
+        return [
+            'boolean false' => [
+                'pressed',
+                false,
+                ['aria-pressed' => 'false'],
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                'pressed',
+                true,
+                ['aria-pressed' => 'true'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with array' => [
+                'controls',
+                static fn(): array => ['key' => 'value'],
+                ['aria-controls' => ['key' => 'value']],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean false' => [
+                'pressed',
+                static fn(): bool => false,
+                ['aria-pressed' => 'false'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean true' => [
+                'pressed',
+                static fn(): bool => true,
+                ['aria-pressed' => 'true'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with empty string' => [
+                'label',
+                static fn(): string => '',
+                ['aria-label' => ''],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with enum' => [
+                'size',
+                static fn(): ButtonSize => ButtonSize::SMALL,
+                ['aria-size' => ButtonSize::SMALL],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with float' => [
+                'value',
+                static fn(): float => 0.42,
+                ['aria-value' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with integer' => [
+                'value',
+                static fn(): int => 42,
+                ['aria-value' => 42],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with null' => [
+                'label',
+                static fn(): null|string => null,
+                [],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with string' => [
+                'label',
+                static fn(): string => 'Close',
+                ['aria-label' => 'Close'],
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                'label',
+                '',
+                ['aria-label' => ''],
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum value' => [
+                'size',
+                ButtonSize::SMALL,
+                ['aria-size' => ButtonSize::SMALL],
+                'Should return the attribute value after setting it.',
+            ],
+            'float' => [
+                'value',
+                0.42,
+                ['aria-value' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'hyphenated key' => [
+                'described-by',
+                'desc',
+                ['aria-described-by' => 'desc'],
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                'value',
+                42,
+                ['aria-value' => 42],
+                'Should return the attribute value after setting it.',
+            ],
+            'mixed string and closure' => [
+                'controls',
+                static fn(): string => 'modal-1',
+                ['aria-controls' => 'modal-1'],
+                'Should return the attribute value after setting it.',
+            ],
+            'multiple string' => [
+                'live',
+                'polite',
+                ['aria-live' => 'polite'],
+                'Should return the attribute value after setting it.',
+            ],
+            'string' => [
+                'label',
+                'Close',
+                ['aria-label' => 'Close'],
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                'label',
+                $stringable,
+                ['aria-label' => $stringable],
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                'label',
+                null,
+                [],
+                "Should unset the 'aria-label' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for HTML `aria-*` attribute map scenarios.
+     *
+     * Supplies test data for validating bulk assignment, normalization, and removal of HTML `aria-*` attributes,
+     * ensuring consistent key prefixing (`aria-`), hyphenated key handling, and value propagation for scalars,
+     * Stringable, UnitEnum, \Closure, and `null`.
+     *
+     * Each test case includes the input value, the expected normalized attributes array, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `aria-*` attribute map scenarios.
+     *
+     * @phpstan-return array<string, array{mixed[], mixed[], string}>
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+
+        $staticCases = [
+            'boolean false' => [
+                ['pressed' => false],
+                ['aria-pressed' => 'false'],
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                ['pressed' => true],
+                ['aria-pressed' => 'true'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with array' => [
+                ['controls' => static fn(): array => ['key' => 'value']],
+                ['aria-controls' => ['key' => 'value']],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean false' => [
+                ['pressed' => static fn(): bool => false],
+                ['aria-pressed' => 'false'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with boolean true' => [
+                ['pressed' => static fn(): bool => true],
+                ['aria-pressed' => 'true'],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with empty string' => [
+                ['label' => static fn(): string => ''],
+                ['aria-label' => ''],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with enum' => [
+                ['size' => static fn(): ButtonSize => ButtonSize::SMALL],
+                ['aria-size' => ButtonSize::SMALL],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with float' => [
+                ['value' => static fn(): float => 0.42],
+                ['aria-value' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with integer' => [
+                ['value' => static fn(): int => 42],
+                ['aria-value' => 42],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with null' => [
+                ['label' => static fn(): null|string => null],
+                [],
+                'Should return the attribute value after setting it.',
+            ],
+            'closure with string' => [
+                ['label' => static fn(): string => 'Close'],
+                ['aria-label' => 'Close'],
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                ['label' => ''],
+                ['aria-label' => ''],
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum value' => [
+                ['size' => ButtonSize::SMALL],
+                ['aria-size' => ButtonSize::SMALL],
+                'Should return the attribute value after setting it.',
+            ],
+            'float' => [
+                ['value' => 0.42],
+                ['aria-value' => 0.42],
+                'Should return the attribute value after setting it.',
+            ],
+            'hyphenated key' => [
+                ['described-by' => 'desc'],
+                ['aria-described-by' => 'desc'],
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                ['value' => 42],
+                ['aria-value' => 42],
+                'Should return the attribute value after setting it.',
+            ],
+            'mixed string and closure' => [
+                [
+                    'label' => 'Close',
+                    'controls' => static fn(): string => 'modal-1',
+                ],
+                [
+                    'aria-label' => 'Close',
+                    'aria-controls' => 'modal-1',
+                ],
+                "Should set multiple 'aria' attributes with mixed string and closure values.",
+            ],
+            'multiple string' => [
+                [
+                    'label' => 'Close',
+                    'live' => 'polite',
+                    'value' => 'value',
+                ],
+                [
+                    'aria-label' => 'Close',
+                    'aria-live' => 'polite',
+                    'aria-value' => 'value',
+                ],
+                "Should set multiple 'aria' attributes with string values.",
+            ],
+            'string' => [
+                ['label' => 'Close'],
+                ['aria-label' => 'Close'],
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                ['label' => $stringable],
+                ['aria-label' => $stringable],
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                ['label' => null],
+                [],
+                "Should unset the 'aria-label' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return $staticCases;
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ARIA attribute support added to block, inline, and void elements with immutable setters and a new enum of ARIA identifiers.
* **Tests**
  * Extensive unit tests and data providers added to validate ARIA/data attribute rendering, value types, immutability, and error cases.
* **Refactor**
  * Consolidated/renamed attribute validation messages for consistency.
* **Documentation**
  * Changelog updated with the new ARIA trait entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->