### PR TITLE
fix(tests): Remove redundant test cases for multiple string `aria-*` attributes in `AriaProvider` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Enh #22: Add `HasRole` trait with `role()` method and tests (@terabytesoftw)
 - Enh #23: Add `HasAria` trait with `aria()` method and tests (@terabytesoftw)
 - Bug #24: Improve `HasData` trait to support closure evaluation for `data-*` attributes (@terabytesoftw)
+- Bug #25: Remove redundant test cases for multiple string `aria-*` attributes in `AriaProvider` class (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/tests/Support/Provider/Attribute/AriaProvider.php
+++ b/tests/Support/Provider/Attribute/AriaProvider.php
@@ -153,16 +153,6 @@ final class AriaProvider
                 ' aria-label="Close" aria-controls="modal-1"',
                 "Should set multiple 'aria' attributes with mixed string and closure values.",
             ],
-            'multiple string' => [
-                [
-                    'label' => 'Close',
-                    'live' => 'polite',
-                    'value' => 'value',
-                ],
-                [],
-                ' aria-label="Close" aria-live="polite" aria-value="value"',
-                "Should set multiple 'aria' attributes with string values.",
-            ],
             'string' => [
                 ['label' => 'Close'],
                 [],
@@ -320,12 +310,6 @@ final class AriaProvider
                 ['aria-controls' => 'modal-1'],
                 'Should return the attribute value after setting it.',
             ],
-            'multiple string' => [
-                'live',
-                'polite',
-                ['aria-live' => 'polite'],
-                'Should return the attribute value after setting it.',
-            ],
             'string' => [
                 'label',
                 'Close',
@@ -461,19 +445,6 @@ final class AriaProvider
                     'aria-controls' => 'modal-1',
                 ],
                 "Should set multiple 'aria' attributes with mixed string and closure values.",
-            ],
-            'multiple string' => [
-                [
-                    'label' => 'Close',
-                    'live' => 'polite',
-                    'value' => 'value',
-                ],
-                [
-                    'aria-label' => 'Close',
-                    'aria-live' => 'polite',
-                    'aria-value' => 'value',
-                ],
-                "Should set multiple 'aria' attributes with string values.",
             ],
             'string' => [
                 ['label' => 'Close'],


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed redundant test cases for aria attribute configurations to streamline the test suite.

* **Chores**
  * Updated changelog with project improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->