### PR TITLE
feat(values): Add `AttributeProperty` enum to standardize common HTML attribute names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enh #23: Add `HasAria` trait with `aria()` method and tests (@terabytesoftw)
 - Bug #24: Improve `HasData` trait to support closure evaluation for `data-*` attributes (@terabytesoftw)
 - Bug #25: Remove redundant test cases for multiple string `aria-*` attributes in `AriaProvider` class (@terabytesoftw)
+- Enh #26: Add `AttributeProperty` enum to standardize common HTML attribute names (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/src/Values/AttributeProperty.php
+++ b/src/Values/AttributeProperty.php
@@ -38,14 +38,14 @@ enum AttributeProperty: string
     case ACCESSKEY = 'accesskey';
 
     /**
-     * `action` — The URI of a program that processes the information submitted via the form.
-     */
-    case ACTION = 'action';
-
-    /**
      * `align` — (Deprecated) Specifies the horizontal alignment of the element.
      */
     case ALIGN = 'align';
+
+    /**
+     * `action` — The URI of a program that processes the information submitted via the form.
+     */
+    case ACTION = 'action';
 
     /**
      * `allow` — Specifies a feature policy for an iframe.
@@ -161,11 +161,6 @@ enum AttributeProperty: string
      * `class` — Space-separated list of classes for the element.
      */
     case CSS_CLASS = 'class';
-
-    /**
-     * `data-*` — Allows custom data attributes on elements. Specific data keys are represented in `DataProperty`.
-     */
-    case DATA = 'data-*';
 
     /**
      * `datetime` — Date and time associated with the element (e.g., `<time>`).
@@ -331,11 +326,6 @@ enum AttributeProperty: string
      * `lang` — Language code for the element's content.
      */
     case LANG = 'lang';
-
-    /**
-     * `language` — (Deprecated) Defines the scripting language.
-     */
-    case LANGUAGE = 'language';
 
     /**
      * `list` — Identifies a `datalist` element that provides predefined options.
@@ -566,11 +556,6 @@ enum AttributeProperty: string
      * `style` — Inline CSS styles for the element.
      */
     case STYLE = 'style';
-
-    /**
-     * `summary` — (Deprecated) Summary of the table's purpose.
-     */
-    case SUMMARY = 'summary';
 
     /**
      * `tabindex` — Overrides the browser's default tab order.

--- a/src/Values/AttributeProperty.php
+++ b/src/Values/AttributeProperty.php
@@ -38,14 +38,14 @@ enum AttributeProperty: string
     case ACCESSKEY = 'accesskey';
 
     /**
-     * `align` — (Deprecated) Specifies the horizontal alignment of the element.
-     */
-    case ALIGN = 'align';
-
-    /**
      * `action` — The URI of a program that processes the information submitted via the form.
      */
     case ACTION = 'action';
+
+    /**
+     * `align` — (Deprecated) Specifies the horizontal alignment of the element.
+     */
+    case ALIGN = 'align';
 
     /**
      * `allow` — Specifies a feature policy for an iframe.

--- a/src/Values/AttributeProperty.php
+++ b/src/Values/AttributeProperty.php
@@ -1,0 +1,619 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Values;
+
+/**
+ * Represents standardized HTML attribute names.
+ *
+ * Provides a type-safe, standards-compliant set of attribute identifiers for use in element rendering, tag helpers and
+ * view helpers. The enum values match the attribute names as used in HTML source.
+ *
+ * Key features.
+ * - Designed for use in tags, components, and helpers requiring attribute assignment.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Values follow the MDN HTML attribute reference.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum AttributeProperty: string
+{
+    /**
+     * `accept` — List of types the server accepts, typically a file type.
+     */
+    case ACCEPT = 'accept';
+
+    /**
+     * `accept-charset` — The character encoding for form submission (historical use; usually "UTF-8").
+     */
+    case ACCEPT_CHARSET = 'accept-charset';
+
+    /**
+     * `accesskey` — Keyboard shortcut to activate or add focus to the element.
+     */
+    case ACCESSKEY = 'accesskey';
+
+    /**
+     * `action` — The URI of a program that processes the information submitted via the form.
+     */
+    case ACTION = 'action';
+
+    /**
+     * `align` — (Deprecated) Specifies the horizontal alignment of the element.
+     */
+    case ALIGN = 'align';
+
+    /**
+     * `allow` — Specifies a feature policy for an iframe.
+     */
+    case ALLOW = 'allow';
+
+    /**
+     * `alt` — Alternative text in case an image can't be displayed.
+     */
+    case ALT = 'alt';
+
+    /**
+     * `async` — Execute the script asynchronously.
+     */
+    case ASYNC = 'async';
+
+    /**
+     * `autocapitalize` — Controls whether and how text input is automatically capitalized.
+     */
+    case AUTOCAPITALIZE = 'autocapitalize';
+
+    /**
+     * `autocomplete` — Indicates whether controls can have their values automatically completed.
+     */
+    case AUTOCOMPLETE = 'autocomplete';
+
+    /**
+     * `autofocus` — A hint that the element should be focused on page load.
+     */
+    case AUTOFOCUS = 'autofocus';
+
+    /**
+     * `autoplay` — The audio or video should play as soon as possible.
+     */
+    case AUTOPLAY = 'autoplay';
+
+    /**
+     * `background` — (Legacy) Specifies the URL of a background image.
+     */
+    case BACKGROUND = 'background';
+
+    /**
+     * `bgcolor` — (Legacy) Background color of the element.
+     */
+    case BGCOLOR = 'bgcolor';
+
+    /**
+     * `border` — (Legacy) The border width.
+     */
+    case BORDER = 'border';
+
+    /**
+     * `capture` — Media capture hint for file inputs.
+     */
+    case CAPTURE = 'capture';
+
+    /**
+     * `charset` — Declares the character encoding of the page or script.
+     */
+    case CHARSET = 'charset';
+
+    /**
+     * `checked` — Indicates whether the element should be checked on page load.
+     */
+    case CHECKED = 'checked';
+
+    /**
+     * `cite` — Contains a URI which points to the source of a quote or change.
+     */
+    case CITE = 'cite';
+
+    /**
+     * `color` — (Legacy) Sets the text color.
+     */
+    case COLOR = 'color';
+
+    /**
+     * `cols` — Number of columns for a textarea.
+     */
+    case COLS = 'cols';
+
+    /**
+     * `colspan` — Number of columns a table cell should span.
+     */
+    case COLSPAN = 'colspan';
+
+    /**
+     * `content` — A value associated with a meta element.
+     */
+    case CONTENT = 'content';
+
+    /**
+     * `contenteditable` — Indicates whether the element's content is editable.
+     */
+    case CONTENTEDITABLE = 'contenteditable';
+
+    /**
+     * `controls` — Indicates whether media controls should be shown.
+     */
+    case CONTROLS = 'controls';
+
+    /**
+     * `coords` — Coordinates for area elements.
+     */
+    case COORDS = 'coords';
+
+    /**
+     * `crossorigin` — How the element handles cross-origin requests.
+     */
+    case CROSSORIGIN = 'crossorigin';
+
+    /**
+     * `class` — Space-separated list of classes for the element.
+     */
+    case CSS_CLASS = 'class';
+
+    /**
+     * `data-*` — Allows custom data attributes on elements. Specific data keys are represented in `DataProperty`.
+     */
+    case DATA = 'data-*';
+
+    /**
+     * `datetime` — Date and time associated with the element (e.g., `<time>`).
+     */
+    case DATETIME = 'datetime';
+
+    /**
+     * `decoding` — Preferred method to decode an image.
+     */
+    case DECODING = 'decoding';
+
+    /**
+     * `defer` — Indicates that the script should be executed after the page has been parsed.
+     */
+    case DEFER = 'defer';
+
+    /**
+     * `dir` — Text direction (ltr/rtl).
+     */
+    case DIR = 'dir';
+
+    /**
+     * `dirname` — Indicates that the element's text directionality should be submitted with the form control.
+     */
+    case DIRNAME = 'dirname';
+
+    /**
+     * `disabled` — Indicates that the user cannot interact with the element.
+     */
+    case DISABLED = 'disabled';
+
+    /**
+     * `download` — Indicates that the hyperlink is to be used for downloading a resource.
+     */
+    case DOWNLOAD = 'download';
+
+    /**
+     * `draggable` — Defines whether the element can be dragged.
+     */
+    case DRAGGABLE = 'draggable';
+
+    /**
+     * `enctype` — Content type of the form data when method is POST.
+     */
+    case ENCTYPE = 'enctype';
+
+    /**
+     * `enterkeyhint` — Hint for the enter key on virtual keyboards.
+     */
+    case ENTERKEYHINT = 'enterkeyhint';
+
+    /**
+     * `fetchpriority` — Fetch priority hint for certain resources (images, links, scripts).
+     */
+    case FETCHPRIORITY = 'fetchpriority';
+
+    /**
+     * `for` — Identifies the element(s) which the label is bound to.
+     */
+    case FOR = 'for';
+
+    /**
+     * `form` — Indicates the form owner of a control.
+     */
+    case FORM = 'form';
+
+    /**
+     * `formaction` — Overrides the action attribute of the form for a submit button.
+     */
+    case FORMACTION = 'formaction';
+
+    /**
+     * `formenctype` — Overrides the form enctype for a submit button.
+     */
+    case FORMENCTYPE = 'formenctype';
+
+    /**
+     * `formmethod` — Overrides the form method for a submit button.
+     */
+    case FORMMETHOD = 'formmethod';
+
+    /**
+     * `formnovalidate` — When present, form is not validated on submit for this button.
+     */
+    case FORMNOVALIDATE = 'formnovalidate';
+
+    /**
+     * `formtarget` — Overrides the form target for a submit button.
+     */
+    case FORMTARGET = 'formtarget';
+
+    /**
+     * `headers` — IDs of `<th>` elements which apply to this cell.
+     */
+    case HEADERS = 'headers';
+
+    /**
+     * `height` — Specifies the height of certain elements.
+     */
+    case HEIGHT = 'height';
+
+    /**
+     * `hidden` — Prevents rendering of the element.
+     */
+    case HIDDEN = 'hidden';
+
+    /**
+     * `high` — Upper bound of the upper range for `<meter>`.
+     */
+    case HIGH = 'high';
+
+    /**
+     * `href` — The URL of a linked resource.
+     */
+    case HREF = 'href';
+
+    /**
+     * `hreflang` — Specifies the language of the linked resource.
+     */
+    case HREFLANG = 'hreflang';
+
+    /**
+     * `http-equiv` — Defines a pragma directive for meta elements.
+     */
+    case HTTP_EQUIV = 'http-equiv';
+
+    /**
+     * `id` — Unique identifier for the element.
+     */
+    case ID = 'id';
+
+    /**
+     * `inputmode` — Hint about what kind of input modality (e.g., numeric) is expected.
+     */
+    case INPUTMODE = 'inputmode';
+
+    /**
+     * `integrity` — Subresource integrity metadata for fetched resources.
+     */
+    case INTEGRITY = 'integrity';
+
+    /**
+     * `ismap` — Indicates that the image is part of a server-side image map.
+     */
+    case ISMAP = 'ismap';
+
+    /**
+     * `itemprop` — Microdata item property name.
+     */
+    case ITEMPROP = 'itemprop';
+
+    /**
+     * `kind` — Kind of text track for `<track>` elements.
+     */
+    case KIND = 'kind';
+
+    /**
+     * `label` — User-readable title of the element.
+     */
+    case LABEL = 'label';
+
+    /**
+     * `lang` — Language code for the element's content.
+     */
+    case LANG = 'lang';
+
+    /**
+     * `language` — (Deprecated) Defines the scripting language.
+     */
+    case LANGUAGE = 'language';
+
+    /**
+     * `list` — Identifies a `datalist` element that provides predefined options.
+     */
+    case LIST = 'list';
+
+    /**
+     * `loading` — Lazy or eager loading hint for images and iframes.
+     */
+    case LOADING = 'loading';
+
+    /**
+     * `loop` — Indicates whether media should loop.
+     */
+    case LOOP = 'loop';
+
+    /**
+     * `low` — Upper bound of the lower range for `<meter>`.
+     */
+    case LOW = 'low';
+
+    /**
+     * `max` — Maximum numeric value for inputs and other controls.
+     */
+    case MAX = 'max';
+
+    /**
+     * `maxlength` — Maximum number of characters allowed.
+     */
+    case MAXLENGTH = 'maxlength';
+
+    /**
+     * `media` — Hint describing the media for which the resource is designed.
+     */
+    case MEDIA = 'media';
+
+    /**
+     * `method` — HTTP method used to submit a form (GET or POST).
+     */
+    case METHOD = 'method';
+
+    /**
+     * `min` — Minimum numeric value for inputs and other controls.
+     */
+    case MIN = 'min';
+
+    /**
+     * `minlength` — Minimum number of characters required.
+     */
+    case MINLENGTH = 'minlength';
+
+    /**
+     * `multiple` — Indicates that multiple values can be selected.
+     */
+    case MULTIPLE = 'multiple';
+
+    /**
+     * `muted` — Indicates whether the media should be muted by default.
+     */
+    case MUTED = 'muted';
+
+    /**
+     * `name` — Name of the element, commonly used in form submissions.
+     */
+    case NAME = 'name';
+
+    /**
+     * `novalidate` — Indicates that a form shouldn't be validated on submit.
+     */
+    case NOVALIDATE = 'novalidate';
+
+    /**
+     * `open` — Indicates whether details/dialog are open.
+     */
+    case OPEN = 'open';
+
+    /**
+     * `optimum` — Optimal numeric value for `<meter>`.
+     */
+    case OPTIMUM = 'optimum';
+
+    /**
+     * `pattern` — Regular expression that the input's value must match.
+     */
+    case PATTERN = 'pattern';
+
+    /**
+     * `ping` — Space-separated list of URLs to be notified when the link is followed.
+     */
+    case PING = 'ping';
+
+    /**
+     * `placeholder` — Hint text for inputs and textareas.
+     */
+    case PLACEHOLDER = 'placeholder';
+
+    /**
+     * `playsinline` — Hint to play video inline (not fullscreen).
+     */
+    case PLAYSINLINE = 'playsinline';
+
+    /**
+     * `poster` — URL of poster frame for video.
+     */
+    case POSTER = 'poster';
+
+    /**
+     * `preload` — Hint about what media should be preloaded.
+     */
+    case PRELOAD = 'preload';
+
+    /**
+     * `readonly` — Indicates that the value cannot be modified by the user.
+     */
+    case READONLY = 'readonly';
+
+    /**
+     * `referrerpolicy` — Referrer information to send when fetching the resource.
+     */
+    case REFERRERPOLICY = 'referrerpolicy';
+
+    /**
+     * `rel` — Relationship of the linked resource to the current document.
+     */
+    case REL = 'rel';
+
+    /**
+     * `required` — Indicates that a control must be filled out before submitting the form.
+     */
+    case REQUIRED = 'required';
+
+    /**
+     * `reversed` — Indicates that an ordered list is displayed in descending order.
+     */
+    case REVERSED = 'reversed';
+
+    /**
+     * `role` — Defines an explicit ARIA role for the element.
+     */
+    case ROLE = 'role';
+
+    /**
+     * `rows` — Number of rows for a textarea.
+     */
+    case ROWS = 'rows';
+
+    /**
+     * `rowspan` — Number of rows a table cell should span.
+     */
+    case ROWSPAN = 'rowspan';
+
+    /**
+     * `sandbox` — Restricts capabilities of content in an iframe.
+     */
+    case SANDBOX = 'sandbox';
+
+    /**
+     * `scope` — Scope of a header cell in a table.
+     */
+    case SCOPE = 'scope';
+
+    /**
+     * `selected` — Indicates that an option should be pre-selected on page load.
+     */
+    case SELECTED = 'selected';
+
+    /**
+     * `shape` — Shape for area elements.
+     */
+    case SHAPE = 'shape';
+
+    /**
+     * `size` — Width in characters for inputs or number of items for select.
+     */
+    case SIZE = 'size';
+
+    /**
+     * `sizes` — Sizes attribute for responsive images and links.
+     */
+    case SIZES = 'sizes';
+
+    /**
+     * `slot` — Assigns an element to a named slot in shadow DOM.
+     */
+    case SLOT = 'slot';
+
+    /**
+     * `span` — Number of columns a `<col>` or `<colgroup>` should span.
+     */
+    case SPAN = 'span';
+
+    /**
+     * `spellcheck` — Indicates whether spell checking is enabled for the element.
+     */
+    case SPELLCHECK = 'spellcheck';
+
+    /**
+     * `src` — URL of embeddable content.
+     */
+    case SRC = 'src';
+
+    /**
+     * `srcdoc` — HTML content for an iframe.
+     */
+    case SRCDOC = 'srcdoc';
+
+    /**
+     * `srclang` — Language of the track text data.
+     */
+    case SRCLANG = 'srclang';
+
+    /**
+     * `srcset` — One or more responsive image candidates.
+     */
+    case SRCSET = 'srcset';
+
+    /**
+     * `start` — Starting value for ordered lists.
+     */
+    case START = 'start';
+
+    /**
+     * `step` — Granularity of numeric inputs.
+     */
+    case STEP = 'step';
+
+    /**
+     * `style` — Inline CSS styles for the element.
+     */
+    case STYLE = 'style';
+
+    /**
+     * `summary` — (Deprecated) Summary of the table's purpose.
+     */
+    case SUMMARY = 'summary';
+
+    /**
+     * `tabindex` — Overrides the browser's default tab order.
+     */
+    case TABINDEX = 'tabindex';
+
+    /**
+     * `target` — Where to display the response after following a link or submitting a form.
+     */
+    case TARGET = 'target';
+
+    /**
+     * `title` — Advisory title for the element (often shown as a tooltip).
+     */
+    case TITLE = 'title';
+
+    /**
+     * `translate` — Whether the element's content should be translated.
+     */
+    case TRANSLATE = 'translate';
+
+    /**
+     * `type` — Type information for various elements (input, script, link, etc.).
+     */
+    case TYPE = 'type';
+
+    /**
+     * `usemap` — Indicates an image is associated with a client-side image map.
+     */
+    case USEMAP = 'usemap';
+
+    /**
+     * `value` — Default value for form controls and other elements.
+     */
+    case VALUE = 'value';
+
+    /**
+     * `width` — Specifies the width of certain elements.
+     */
+    case WIDTH = 'width';
+
+    /**
+     * `wrap` — Indicates how text should be wrapped in a textarea.
+     */
+    case WRAP = 'wrap';
+}

--- a/tests/Mixin/HasAttributesTest.php
+++ b/tests/Mixin/HasAttributesTest.php
@@ -12,6 +12,7 @@ use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Mixin\AttributeProvider;
 use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
+use UnitEnum;
 
 /**
  * Test suite for {@see HasAttributes} mixin functionality and behavior.
@@ -113,7 +114,7 @@ final class HasAttributesTest extends TestCase
      */
     #[DataProviderExternal(AttributeProvider::class, 'value')]
     public function testSetSingleAttributeValue(
-        string $key,
+        string|UnitEnum $key,
         bool|float|int|string|Closure|null $value,
         array $expected,
         string $message,

--- a/tests/Support/Provider/Mixin/AttributeProvider.php
+++ b/tests/Support/Provider/Mixin/AttributeProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Support\Provider\Mixin;
 
+use UIAwesome\Html\Core\Values\AttributeProperty;
+use UnitEnum;
+
 /**
  * Data provider for {@see \UIAwesome\Html\Core\Tests\Mixin\HasAttributesTest} class.
  *
@@ -32,20 +35,31 @@ final class AttributeProvider
      * Provides test cases for single HTML attribute scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of a single HTML attribute, including string
-     * keys and values provided as scalars, \Closure, and `null`.
+     * keys, UnitEnum keys and values provided as scalars, \Closure, and `null`.
      *
      * Each test case includes the attribute key, the input value, the expected attributes array, and an assertion
      * message for clear identification.
      *
      * @return array Test data for single attribute scenarios.
      *
-     * @phpstan-return array<string, array{string, scalar|\Closure(): mixed|null, mixed[], string}>
+     * @phpstan-return array<string, array{string|UnitEnum, scalar|\Closure(): mixed|null, mixed[], string}>
      */
     public static function value(): array
     {
         $closure = static fn(): string => 'my-value';
 
-        return [
+        $enumCases = [];
+
+        foreach (AttributeProperty::cases() as $case) {
+            $enumCases["AttributeProperty::{$case->name}"] = [
+                $case,
+                '',
+                [$case->value => ''],
+                "Should return the attribute '{$case->value}' after setting it.",
+            ];
+        }
+
+        $staticCases = [
             'boolean false' => [
                 'disabled',
                 false,
@@ -101,6 +115,8 @@ final class AttributeProvider
                 "Should unset the 'class' attribute when 'null' is provided after a value.",
             ],
         ];
+
+        return [...$staticCases, ...$enumCases];
     }
 
     /**
@@ -109,8 +125,8 @@ final class AttributeProvider
      * Supplies test data for validating bulk assignment, normalization, and removal of HTML attributes, ensuring
      * consistent key handling, hyphenated key support, and value propagation for scalars, \Closure, and `null`.
      *
-     * Each test case includes the input values map, the expected normalized attributes array, and an assertion
-     * message for clear identification.
+     * Each test case includes the input values map, the expected normalized attributes array, and an assertion message
+     * for clear identification.
      *
      * @return array Test data for attribute value map scenarios.
      *
@@ -166,32 +182,6 @@ final class AttributeProvider
                     'class' => $closure,
                 ],
                 'Should set multiple attributes with mixed string and closure values.',
-            ],
-            'multiple attributes' => [
-                [
-                    'id' => 'my-id',
-                    'class' => 'my-class',
-                    'disabled' => true,
-                ],
-                [
-                    'id' => 'my-id',
-                    'class' => 'my-class',
-                    'disabled' => true,
-                ],
-                'Should set multiple attributes with various value types.',
-            ],
-            'multiple string' => [
-                [
-                    'id' => 'my-id',
-                    'class' => 'my-class',
-                    'title' => 'my-title',
-                ],
-                [
-                    'id' => 'my-id',
-                    'class' => 'my-class',
-                    'title' => 'my-title',
-                ],
-                'Should set multiple attributes with string values.',
             ],
             'string' => [
                 ['id' => 'my-id'],


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the AttributeProperty enum — a centralized, type-safe registry of standard HTML attribute names (including data-, aria-, and form-related attributes).

* **Tests**
  * Updated tests and test data to accept enum-based attribute keys alongside strings and simplified some bulk-attribute test cases.

* **Documentation**
  * Added a changelog entry describing the new enum.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->