### PR TITLE
test(tests): Improve `HasAriaTest` with additional test cases for invalid `aria-*` attribute keys and `AriaProvider` data provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bug #27: Update `style()` method to accept array as a valid input type in `HasStyle` trait (@terabytesoftw)
 - Bug #28: Improve `HasAriaTest` and `AriaProvider` with comprehensive test coverage for `aria-*` attributes (@terabytesoftw)
 - Enh #29: Add `HasEvents` trait with `events()`, `addEvent()`, `removeEvent()` methods and tests (@terabytesoftw)
+- Bug #30: Improve `HasAriaTest` with additional test cases for invalid `aria-*` attribute keys and `AriaProvider` data provider (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/tests/Attribute/HasAriaTest.php
+++ b/tests/Attribute/HasAriaTest.php
@@ -14,7 +14,6 @@ use UIAwesome\Html\Core\Attribute\HasAria;
 use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\AriaProvider;
-use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
 use UIAwesome\Html\Helper\Attributes;
 use UnitEnum;
 
@@ -63,6 +62,19 @@ final class HasAriaTest extends TestCase
             $expected,
             Attributes::render($instance->getAttributes()),
             $message,
+        );
+    }
+
+    public function testReturnEmptyWhenAriaAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAria;
+            use HasAttributes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
         );
     }
 
@@ -151,8 +163,30 @@ final class HasAriaTest extends TestCase
         $instance->ariaAttributes(['key' => new stdClass()]);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsEmpty(): void
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AriaProvider::class, 'invalidKey')]
+    public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsInvalid(array $attributes): void
     {
+        $instance = new class {
+            use HasAria;
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+        );
+
+        $instance->ariaAttributes($attributes);
+    }
+
+    #[DataProviderExternal(AriaProvider::class, 'invalidSingleKey')]
+    public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeKeyIsInvalid(
+        string|UnitEnum $key,
+        string $value,
+    ): void {
         $instance = new class {
             use HasAria;
             use HasAttributes;
@@ -163,51 +197,6 @@ final class HasAriaTest extends TestCase
             Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
         );
 
-        $instance->ariaAttributes(['' => 'value']);
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetAriaAttributeKeyIsInvalid(): void
-    {
-        $instance = new class {
-            use HasAria;
-            use HasAttributes;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(1),
-        );
-
-        $instance->ariaAttributes([1 => '']);
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithEmptyKey(): void
-    {
-        $instance = new class {
-            use HasAria;
-            use HasAttributes;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
-        );
-
-        $instance->addAriaAttribute('', 'value');
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetSingleAriaAttributeWithInvalidKey(): void
-    {
-        $instance = new class {
-            use HasAria;
-            use HasAttributes;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(2),
-        );
-
-        $instance->addAriaAttribute(Priority::HIGH, 'value');
+        $instance->addAriaAttribute($key, $value);
     }
 }

--- a/tests/Attribute/HasAriaTest.php
+++ b/tests/Attribute/HasAriaTest.php
@@ -194,7 +194,7 @@ final class HasAriaTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
         );
 
         $instance->addAriaAttribute($key, $value);

--- a/tests/Support/Provider/Attribute/AriaProvider.php
+++ b/tests/Support/Provider/Attribute/AriaProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Support\Provider\Attribute;
 
 use Stringable;
-use UIAwesome\Html\Core\Tests\Support\Stub\Enum\ButtonSize;
+use UIAwesome\Html\Core\Tests\Support\Stub\Enum\{ButtonSize, Priority};
 use UIAwesome\Html\Core\Values\Aria;
 use UnitEnum;
 
@@ -33,6 +33,69 @@ use UnitEnum;
  */
 final class AriaProvider
 {
+    /**
+     * Provides test cases for invalid HTML `aria-*` attribute keys.
+     *
+     * Supplies test data for validating exception handling when setting HTML `aria-*` attributes with invalid keys,
+     * including empty string and non-string types.
+     *
+     * Each test case includes the invalid key input.
+     *
+     * @return array Test data for invalid `aria-*` attribute keys.
+     *
+     * @phpstan-return array<string, array{mixed[]}>
+     */
+    public static function invalidKey(): array
+    {
+        return [
+            'boolean false' => [
+                [false => 'value'],
+            ],
+            'boolean true' => [
+                [true => 'value'],
+            ],
+            'empty string' => [
+                ['' => 'value'],
+            ],
+            'float' => [
+                // @phpstan-ignore-next-line
+                [0.42 => 'value'],
+            ],
+            'integer' => [
+                [1 => 'value'],
+            ],
+            'null' => [
+                [null => 'value'],
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for invalid single HTML `aria-*` attribute keys.
+     *
+     * Supplies test data for validating exception handling when setting a single HTML `aria-*` attribute with an
+     * invalid key, including empty string and UnitEnum.
+     *
+     * Each test case includes the invalid key and value input.
+     *
+     * @return array Test data for invalid single `aria-*` attribute keys.
+     *
+     * @phpstan-return array<string, array{scalar|UnitEnum|null, string}>
+     */
+    public static function invalidSingleKey(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                'value',
+            ],
+            'enum key' => [
+                Priority::HIGH,
+                'value',
+            ],
+        ];
+    }
+
     /**
      * Provides test cases for rendered HTML `aria-*` attribute scenarios.
      *


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aria-* attribute validation and error messages for invalid keys.

* **Tests**
  * Reworked aria attribute tests to be data-driven and added coverage for many invalid-key scenarios.
  * Added a test ensuring no aria attributes are returned when none are set.

* **Documentation**
  * Added changelog entry describing the above fixes and test improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->