### PR TITLE
test(tests): Improve `HasEventsTest` with additional cases for invalid `on-*` attribute keys and improve `EventProvider` data provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bug #28: Improve `HasAriaTest` and `AriaProvider` with comprehensive test coverage for `aria-*` attributes (@terabytesoftw)
 - Enh #29: Add `HasEvents` trait with `events()`, `addEvent()`, `removeEvent()` methods and tests (@terabytesoftw)
 - Bug #30: Improve `HasAriaTest` with additional test cases for invalid `aria-*` attribute keys and `AriaProvider` data provider (@terabytesoftw)
+- Bug #31: Improve `HasEventsTest` with additional cases for invalid `on-*` attribute keys and `EventProvider` data provider (@terabytesoftw)
 
 ## 0.2.0 December 18, 2025
 

--- a/tests/Attribute/HasEventsTest.php
+++ b/tests/Attribute/HasEventsTest.php
@@ -14,7 +14,6 @@ use UIAwesome\Html\Core\Attribute\HasEvents;
 use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\EventProvider;
-use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
 use UIAwesome\Html\Helper\Attributes;
 use UnitEnum;
 
@@ -65,6 +64,19 @@ final class HasEventsTest extends TestCase
             $expected,
             Attributes::render($instance->getAttributes()),
             $message,
+        );
+    }
+
+    public function testReturnEmptyWhenEventAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasEvents;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
         );
     }
 
@@ -154,8 +166,12 @@ final class HasEventsTest extends TestCase
         $instance->events(['onclick' => new stdClass()]);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenRemoveEventAttributeKeyMissingOnPrefix(): void
-    {
+    #[DataProviderExternal(EventProvider::class, 'invalidSingleKey')]
+    public function testThrowInvalidArgumentExceptionWhenRemoveEventAttributeKeyIsInvalid(
+        string|UnitEnum $key,
+        string $handler,
+        string $message,
+    ): void {
         $instance = new class {
             use HasAttributes;
             use HasEvents;
@@ -163,14 +179,20 @@ final class HasEventsTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            Message::EVENT_KEY_MUST_START_WITH_ON->getMessage('invalid-key'),
+            $message,
         );
 
-        $instance->removeEvent('invalid-key');
+        $instance->removeEvent($key);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenRemoveEventAttributeWithEmptyKey(): void
-    {
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(EventProvider::class, 'invalidKey')]
+    public function testThrowInvalidArgumentExceptionWhenSetEventAttributeKeyIsInvalid(
+        array $attributes,
+        string $message,
+    ): void {
         $instance = new class {
             use HasAttributes;
             use HasEvents;
@@ -178,14 +200,18 @@ final class HasEventsTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            $message,
         );
 
-        $instance->removeEvent('');
+        $instance->events($attributes);
     }
 
-    public function testThrowInvalidArgumentExceptionWhenSetEventAttributeKeyIsEmpty(): void
-    {
+    #[DataProviderExternal(EventProvider::class, 'invalidSingleKey')]
+    public function testThrowInvalidArgumentExceptionWhenSetSingleEventAttributeKeyIsInvalid(
+        string|UnitEnum $key,
+        string $handler,
+        string $message,
+    ): void {
         $instance = new class {
             use HasAttributes;
             use HasEvents;
@@ -193,84 +219,9 @@ final class HasEventsTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            $message,
         );
 
-        $instance->events(['' => "alert('test')"]);
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetEventAttributeKeyIsInvalid(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-            use HasEvents;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-        );
-
-        $instance->events([1 => "alert('test')"]);
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetEventAttributeKeyMissingOnPrefix(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-            use HasEvents;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::EVENT_KEY_MUST_START_WITH_ON->getMessage('invalid-key'),
-        );
-
-        $instance->events(['invalid-key' => "alert('test')"]);
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetSingleEventAttributeKeyMissingOnPrefix(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-            use HasEvents;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::EVENT_KEY_MUST_START_WITH_ON->getMessage('invalid-key'),
-        );
-
-        $instance->addEvent('invalid-key', "alert('test')");
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetSingleEventAttributeWithEmptyKey(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-            use HasEvents;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-        );
-
-        $instance->addEvent('', "alert('test')");
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenSetSingleEventAttributeWithInvalidKey(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-            use HasEvents;
-        };
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
-        );
-
-        $instance->addEvent(Priority::HIGH, "alert('test')");
+        $instance->addEvent($key, $handler);
     }
 }

--- a/tests/Support/Provider/Attribute/EventProvider.php
+++ b/tests/Support/Provider/Attribute/EventProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Support\Provider\Attribute;
 
 use Stringable;
+use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Tests\Support\Stub\Enum\Priority;
 use UIAwesome\Html\Core\Values\Event;
 use UnitEnum;
@@ -33,6 +34,81 @@ use UnitEnum;
  */
 final class EventProvider
 {
+    /**
+     * Provides test cases for invalid HTML `on-*` attribute keys.
+     *
+     * Supplies test data for validating exception handling when setting HTML `on-*` attributes with invalid keys,
+     * including empty string, UnitEnum and keys without the `on` prefix.
+     *
+     * Each test case includes the invalid key input and an assertion message for clear identification.
+     *
+     * @return array Test data for invalid `on-*` attribute keys.
+     *
+     * @phpstan-return array<string, array{mixed[]}>
+     */
+    public static function invalidKey(): array
+    {
+        return [
+            'boolean false' => [
+                [false => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'boolean true' => [
+                [true => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'empty string' => [
+                ['' => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'integer' => [
+                [1 => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'null' => [
+                [null => 'value'],
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'without on prefix' => [
+                ['invalid-key' => 'value'],
+                Message::EVENT_KEY_MUST_START_WITH_ON->getMessage('invalid-key'),
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for invalid single HTML `on-*` attribute keys.
+     *
+     * Supplies test data for validating exception handling when setting a single HTML `on-*` attribute with an invalid
+     * key, including empty string, UnitEnum and keys without the `on` prefix.
+     *
+     * Each test case includes the attribute key, the input value, and an assertion message for clear identification.
+     *
+     * @return array Test data for invalid single `on-*` attribute keys.
+     *
+     * @phpstan-return array<string, array{scalar|UnitEnum|null, string, string}>
+     */
+    public static function invalidSingleKey(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                'value',
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'enum key' => [
+                Priority::HIGH,
+                'value',
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(),
+            ],
+            'without on prefix' => [
+                'invalid-key',
+                'value',
+                Message::EVENT_KEY_MUST_START_WITH_ON->getMessage('invalid-key'),
+            ],
+        ];
+    }
+
     /**
      * Provides test cases for rendered HTML `on*` event attribute scenarios.
      *

--- a/tests/Support/Provider/Attribute/EventProvider.php
+++ b/tests/Support/Provider/Attribute/EventProvider.php
@@ -44,7 +44,7 @@ final class EventProvider
      *
      * @return array Test data for invalid `on-*` attribute keys.
      *
-     * @phpstan-return array<string, array{mixed[]}>
+     * @phpstan-return array<string, array{mixed[], string}>
      */
     public static function invalidKey(): array
     {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changelog**
  * Added a changelog entry for Bug #31 under version 0.3.0 with notes about added test coverage.

* **Tests**
  * Strengthened event-attribute test coverage with data-driven scenarios covering invalid composite and single keys, empty values, missing event prefixes, and a new assertion that no attributes are produced when none are set; consolidated legacy cases into parameterized providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->