### PR TITLE
feat(tag): Add `SVG` case to `Block` enum for HTML tag representation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #33: Update test group annotations for `BaseTagTest` and `SimpleFactoryTest` classes (@terabytesoftw)
 - Dep #34: Update `infection/infection` version constraint to `^0.32` in `composer.json` (@terabytesoftw)
+- Bug #35: Add `SVG` case to `Block` enum for HTML tag representation (@terabytesoftw)
 
 ## 0.3.0 December 24, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bug #33: Update test group annotations for `BaseTagTest` and `SimpleFactoryTest` classes (@terabytesoftw)
 - Dep #34: Update `infection/infection` version constraint to `^0.32` in `composer.json` (@terabytesoftw)
-- Bug #35: Add `SVG` case to `Block` enum for HTML tag representation (@terabytesoftw)
+- Enh #35: Add `SVG` case to `Block` enum for HTML tag representation (@terabytesoftw)
 
 ## 0.3.0 December 24, 2025
 

--- a/src/Tag/Block.php
+++ b/src/Tag/Block.php
@@ -339,7 +339,7 @@ enum Block: string
      *
      * Categorized as embedded, flow, and palpable content.
      *
-     * @link https://developer.mozilla.org/en-US/docs/Web/SVG
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
      */
     case SVG = 'svg';
 

--- a/src/Tag/Block.php
+++ b/src/Tag/Block.php
@@ -335,6 +335,15 @@ enum Block: string
     case SUMMARY = 'summary';
 
     /**
+     * Case for the `<svg>` HTML tag.
+     *
+     * Categorized as embedded, flow, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG
+     */
+    case SVG = 'svg';
+
+    /**
      * Case for the `<video>` HTML tag.
      *
      * Categorized as embedded, flow, interactive, palpable, and phrasing content.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SVG tag support to the tag system for proper representation and handling of SVG elements in output/markup, improving fidelity when embedding vector graphics and ensuring consistent tag behavior across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->