### PR TITLE
fix(exception): Move `Message` enum to `Helper\Exception` namespace and clean up unused cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.2 Under development
 
+- Bug #37: Move `Message` enum to `Helper\Exception` namespace and clean up unused cases (@terabytesoftw)
+
 ## 0.3.1 December 26, 2025
 
 - Bug #33: Update test group annotations for `BaseTagTest` and `SimpleFactoryTest` classes (@terabytesoftw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## 0.3.2 Under development
+## 0.4.0 Under development
 
 - Bug #37: Move `Message` enum to `Helper\Exception` namespace and clean up unused cases (@terabytesoftw)
 

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -89,28 +89,6 @@ enum Message: string
     case UNEXPECTED_END_CALL_NO_BEGIN = "Unexpected '%s::end()' call, a matching 'begin()' is not found.";
 
     /**
-     * Error when a value can't be empty.
-     *
-     * Format: "The '%s' must not be empty, valid values are: '%s'."
-     */
-    case VALUE_CANNOT_BE_EMPTY = "The '%s' must not be empty, valid values are: '%s'.";
-
-    /**
-     * Error when a value is not in the list of valid values.
-     *
-     * Format: "Value '%s' is not in the list of valid values for '%s': '%s'."
-     */
-    case VALUE_NOT_IN_LIST = "Value '%s' is not in the list of valid values for '%s': '%s'.";
-
-    /**
-     * Error when a value is of an invalid type.
-     *
-     * Format: "Value should be of type 'array', 'scalar', 'null', or 'enum'; '%s' given."
-     */
-    case VALUE_SHOULD_BE_ARRAY_SCALAR_NULL_ENUM = "Value should be of type 'array', 'scalar', 'null', or 'enum'; " .
-    "'%s' given.";
-
-    /**
      * Returns the formatted message string for the error case.
      *
      * Retrieves and formats the error message string by interpolating the provided arguments.

--- a/tests/Attribute/HasContentEditableTest.php
+++ b/tests/Attribute/HasContentEditableTest.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasContentEditable;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\ContentEditableProvider;
 use UIAwesome\Html\Core\Values\ContentEditable;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 /**

--- a/tests/Attribute/HasDirTest.php
+++ b/tests/Attribute/HasDirTest.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasDir;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\DirProvider;
 use UIAwesome\Html\Core\Values\Direction;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 /**

--- a/tests/Attribute/HasDraggableTest.php
+++ b/tests/Attribute/HasDraggableTest.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasDraggable;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\DraggableProvider;
 use UIAwesome\Html\Core\Values\Draggable;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 /**

--- a/tests/Attribute/HasLangTest.php
+++ b/tests/Attribute/HasLangTest.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasLang;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\LangProvider;
 use UIAwesome\Html\Core\Values\Language;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 /**

--- a/tests/Attribute/HasRoleTest.php
+++ b/tests/Attribute/HasRoleTest.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasRole;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\RoleProvider;
 use UIAwesome\Html\Core\Values\Role;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UnitEnum;
 
 /**

--- a/tests/Attribute/HasSpellcheckTest.php
+++ b/tests/Attribute/HasSpellcheckTest.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Attribute\HasSpellcheck;
-use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Mixin\HasAttributes;
 use UIAwesome\Html\Core\Tests\Support\Provider\Attribute\SpellcheckProvider;
 use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Helper\Exception\Message;
 
 /**
  * Test suite for {@see HasSpellcheck} trait functionality and behavior.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Bumped release version to 0.4.0 (under development).

* **Refactor**
  * Reorganized exception message handling into a clearer namespace.
  * Removed several unused error message templates to streamline error output and maintenance.

* **Tests**
  * Updated tests to reference the new message handling location so assertions remain consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->