### PR TITLE
fix(attributes): Update method calls to use `getAttributes()` method for consistency in `BaseBlock`, `BaseInline`, and `BaseVoid` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0 Under development
 
 - Bug #37: Move `Message` enum to `Helper\Exception` namespace and clean up unused cases (@terabytesoftw)
+- Bug #38: Update method calls to use `getAttributes()` method for consistency in `BaseBlock` and `BaseVoid` classes (@terabytesoftw)
 
 ## 0.3.1 December 26, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.4.0 Under development
 
 - Bug #37: Move `Message` enum to `Helper\Exception` namespace and clean up unused cases (@terabytesoftw)
-- Bug #38: Update method calls to use `getAttributes()` method for consistency in `BaseBlock` and `BaseVoid` classes (@terabytesoftw)
+- Bug #38: Update method calls to use `getAttributes()` method for consistency in `BaseBlock`, `BaseInline`, and `BaseVoid` classes (@terabytesoftw)
 
 ## 0.3.1 December 26, 2025
 

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -146,6 +146,6 @@ abstract class BaseBlock extends BaseTag
      */
     protected function runBegin(): string
     {
-        return Html::begin($this->getTag(), $this->attributes);
+        return Html::begin($this->getTag(), $this->getAttributes());
     }
 }

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -125,7 +125,7 @@ abstract class BaseBlock extends BaseTag
     protected function run(): string
     {
         if ($this->isBeginExecuted() === false) {
-            return Html::element($this->getTag(), $this->getContent(), $this->attributes);
+            return Html::element($this->getTag(), $this->getContent(), $this->getAttributes());
         }
 
         return Html::end($this->getTag());

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -97,7 +97,7 @@ abstract class BaseInline extends BaseTag
     {
         $tokenTemplateValues = [
             '{prefix}' => $this->renderTag($this->prefixTag, $this->prefix, $this->prefixAttributes),
-            '{tag}' => $this->renderTag($this->getTag(), (string) $content, $this->attributes),
+            '{tag}' => $this->renderTag($this->getTag(), (string) $content, $this->getAttributes()),
             '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
         ];
 

--- a/src/Element/BaseVoid.php
+++ b/src/Element/BaseVoid.php
@@ -81,6 +81,6 @@ abstract class BaseVoid extends BaseTag
      */
     protected function run(): string
     {
-        return Html::void($this->getTag(), $this->attributes);
+        return Html::void($this->getTag(), $this->getAttributes());
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent attribute handling in element rendering (blocks, inlines and voids), improving rendering reliability (Bug #38).

* **Documentation**
  * Added a changelog entry documenting the fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->