### PR TITLE
dep(dependencies): Update `ui-awesome/html-helper` version constraint to `^0.6` in `composer.json` and adjust related tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bug #38: Update method calls to use `getAttributes()` method for consistency in `BaseBlock`, `BaseInline`, and `BaseVoid` classes (@terabytesoftw)
 - Bug #39: Rename exception test methods for clarity and consistency (@terabytesoftw)
 - Bug #40: Consolidate attribute handling in `setAttribute()` method in `HasAttributes` class and remove redundant code in related classes (@terabytesoftw)
+- Dep #41: Update `ui-awesome/html-helper` version constraint to `^0.6` in `composer.json` and adjust related tests (@terabytesoftw)
 
 ## 0.3.1 December 26, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "ui-awesome/html-helper": "^0.5"
+        "ui-awesome/html-helper": "^0.6"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.32",

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -508,7 +508,7 @@ final class TagBlockTest extends TestCase
     {
         self::equalsWithoutLE(
             <<<HTML
-            <div style="test-value">
+            <div style='test-value'>
             </div>
             HTML,
             TagBlock::tag()->style('test-value')->render(),

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -455,7 +455,7 @@ final class TagInlineTest extends TestCase
     {
         self::equalsWithoutLE(
             <<<HTML
-            <span style="test-value"></span>
+            <span style='test-value'></span>
             HTML,
             TagInline::tag()->style('test-value')->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -246,7 +246,7 @@ final class TagVoidTest extends TestCase
     {
         self::equalsWithoutLE(
             <<<HTML
-            <hr style="test-value">
+            <hr style='test-value'>
             HTML,
             TagVoid::tag()->style('test-value')->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",

--- a/tests/Support/Provider/Attribute/StyleProvider.php
+++ b/tests/Support/Provider/Attribute/StyleProvider.php
@@ -63,13 +63,13 @@ final class StyleProvider
             'enum' => [
                 AlertType::WARNING,
                 [],
-                ' style="warning"',
+                ' style=\'warning\'',
                 'Should return the attribute value after setting it with an enum.',
             ],
             'enum replace existing' => [
                 AlertType::WARNING,
                 ['style' => 'color: red;'],
-                ' style="warning"',
+                ' style=\'warning\'',
                 "Should return new 'style' after replacing the existing 'style' attribute with enum value.",
             ],
             'null' => [
@@ -81,13 +81,13 @@ final class StyleProvider
             'replace existing' => [
                 'color: blue;',
                 ['style' => 'color: red;'],
-                ' style="color: blue;"',
+                ' style=\'color: blue;\'',
                 "Should return new 'style' after replacing the existing 'style' attribute.",
             ],
             'string' => [
                 'color: red;',
                 [],
-                ' style="color: red;"',
+                ' style=\'color: red;\'',
                 'Should return the attribute value after setting it.',
             ],
             'stringable' => [
@@ -98,7 +98,7 @@ final class StyleProvider
                     }
                 },
                 [],
-                ' style="color: green;"',
+                ' style=\'color: green;\'',
                 'Should return the attribute value after setting it with a Stringable instance.',
             ],
             'unset with null' => [


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ui-awesome/html-helper dependency to version ^0.6
  * Updated test expectations to reflect rendering updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->