### PR TITLE
fix(docs): Update usage examples for `getTag()` method in `BaseBlock`, `BaseInline`, and `BaseVoid` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.0 Under development
 
 - Enh #42: Introduce interfaces for block, inline, and void tags; update related classes and tests (@terabytesoftw)
+- Bug #43: Update usage examples for `getTag()` method in `BaseBlock`, `BaseInline`, and `BaseVoid` classes (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -87,7 +87,7 @@ abstract class BaseBlock extends BaseTag
      *
      * Usage example:
      * ```php
-     * public function getTag(): Block|Lists|Root|Table
+     * public function getTag(): BlockInterface
      * {
      *    return Block::DIV;
      * }

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -75,6 +75,14 @@ abstract class BaseInline extends BaseTag
      * Must be implemented by subclasses to specify the concrete inline tag.
      *
      * @return InlineInterface Tag instance for the inline element.
+     *
+     * Usage example:
+     * ```php
+     * public function getTag(): InlineInterface
+     * {
+     *    return Inline::SPAN;
+     * }
+     * ```
      */
     abstract protected function getTag(): InlineInterface;
 

--- a/src/Element/BaseVoid.php
+++ b/src/Element/BaseVoid.php
@@ -69,6 +69,14 @@ abstract class BaseVoid extends BaseTag
      * Must be implemented by subclasses to specify the concrete void tag.
      *
      * @return VoidInterface Tag instance for the void element.
+     *
+     * Usage example:
+     * ```php
+     * public function getTag(): VoidInterface
+     * {
+     *    return Void::IMG;
+     * }
+     * ```
      */
     abstract protected function getTag(): VoidInterface;
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated usage examples for the getTag() method documentation across base element classes to improve clarity and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->