### PR TITLE
feat(tag): Add `loadDefault()` method in `BaseTag` class to provide default attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.3 Under development
 
 - Dep #57: Update `ui-awesome/html-interop` requirement from `^0.2` to `^0.3` in `composer.json` (@terabytesoftw)
+- Enh #58: Add `loadDefault()` method in `BaseTag` class to provide default attribute values (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,48 @@ echo Span::tag(['id' => 'badge-1'])
 // <span class="badge text-muted" id="badge-1" title="from-global">New</span>
 ```
 
+#### Class level defaults with `loadDefault()`
+
+For a simpler approach without separate provider classes, override `loadDefault()` in your tag class. These defaults are
+applied automatically when `tag()` is called.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\{Block, BlockInterface};
+
+final class Container extends BaseBlock
+{
+    protected function getTag(): BlockInterface
+    {
+        return Block::DIV;
+    }
+
+    protected function loadDefaultDefinitions(): array
+    {
+        return [
+            'class' => 'container',
+        ];
+    }
+}
+
+echo Container::tag()->render();
+// <div class="container"></div>
+
+echo Container::tag(['class' => 'container-fluid'])->render();
+// <div class="container-fluid"></div>
+```
+
+Configuration priority (from weakest to strongest):
+1. Global defaults via `SimpleFactory::setDefaults()`
+2. Class defaults from `loadDefault()`
+3. User defaults passed to `tag()`
+
 #### Extensibility
 
 This library is agnostic and designed to be extended. You can define your own tag collections (for example, for SVG,

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ echo Span::tag(['id' => 'badge-1'])
 // <span class="badge text-muted" id="badge-1" title="from-global">New</span>
 ```
 
-#### Class level defaults with `loadDefault()`
+#### Class-level defaults with `loadDefault()`
 
 For a simpler approach without separate provider classes, override `loadDefault()` in your tag class. These defaults are
 applied automatically when `tag()` is called.
@@ -301,7 +301,7 @@ final class Container extends BaseBlock
         return Block::DIV;
     }
 
-    protected function loadDefaultDefinitions(): array
+    protected function loadDefault(): array
     {
         return [
             'class' => 'container',
@@ -317,6 +317,7 @@ echo Container::tag(['class' => 'container-fluid'])->render();
 ```
 
 Configuration priority (from weakest to strongest):
+
 1. Global defaults via `SimpleFactory::setDefaults()`
 2. Class defaults from `loadDefault()`
 3. User defaults passed to `tag()`

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -1,5 +1,5 @@
 <!-- Mobile layout - Single column -->
-<svg fill="none" viewBox="0 0 600 610" width="100%" height="580" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 600 630" width="100%" height="580" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
         <div xmlns="http://www.w3.org/1999/xhtml">
             <style>
@@ -47,7 +47,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Defaults and theming</strong></p>
-                    <p class="alert-content">Configure tags via SimpleFactory defaults, DefaultsProviderInterface and ThemeProviderInterface</p>
+                                        <p class="alert-content">Configure tags via SimpleFactory defaults, DefaultsProviderInterface, ThemeProviderInterface, or override loadDefault() for class-level defaults</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Extensible base elements</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -44,7 +44,7 @@
             <div class="container">
                 <div class="alert-box">
                     <p class="alert-title"><strong>Defaults and theming</strong></p>
-                    <p class="alert-content">Configure tags via SimpleFactory defaults, DefaultsProviderInterface and ThemeProviderInterface</p>
+                    <p class="alert-content">Configure tags via SimpleFactory defaults, DefaultsProviderInterface, ThemeProviderInterface, or override loadDefault() for class-level defaults</p>
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>Extensible base elements</strong></p>

--- a/src/Base/BaseTag.php
+++ b/src/Base/BaseTag.php
@@ -319,6 +319,7 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
      *
      * Configuration priority (from weakest to strongest):
      * - Global defaults defined via {@see SimpleFactory::setDefaults()}.
+     * - Class defaults from {@see BaseTag::loadDefault()}.
      * - Defaults passed directly by the user to {@see tag()}.
      *
      * After construction, additional user modifications (via setter methods like `class`, `id`, `data`, etc.) and
@@ -348,6 +349,7 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
 
         $pipeline = [
             SimpleFactory::getDefaults(static::class),
+            $tag->loadDefault(),
             ...$defaults,
         ];
 
@@ -371,6 +373,37 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
     protected function isBeginExecuted(): bool
     {
         return $this->beginExecuted;
+    }
+
+    /**
+     * Returns default definitions for the tag class.
+     *
+     * Provides a cookbook style array of default configurations that are applied when the tag is instantiated.
+     *
+     * These defaults have the medium priority in the configuration pipeline.
+     *
+     * Override this method in subclasses to provide class specific default values.
+     *
+     * @return array<string, mixed> Cookbook style configuration array.
+     *
+     * @phpstan-return mixed[]
+     *
+     * Usage example:
+     * ```php
+     * protected function loadDefault(): array
+     * {
+     *     $shortClassName = Utils::getShortNameClass(static::class, false, true);
+     *
+     *     return [
+     *         'id()' => [Utils::generateId("$shortClassName-")],
+     *         'template()' => ['{prefix}\n{tag}\n{suffix}'],
+     *     ];
+     * }
+     * ```
+     */
+    protected function loadDefault(): array
+    {
+        return [];
     }
 
     /**

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -494,7 +494,7 @@ final class TagBlockTest extends TestCase
         );
     }
 
-    public function testRenderWithLoadDefaultDefinitions(): void
+    public function testRenderWithLoadDefault(): void
     {
         self::assertEquals(
             <<<HTML
@@ -720,7 +720,7 @@ final class TagBlockTest extends TestCase
         );
     }
 
-    public function testReturnEmptyArrayWhenLoadDefaultDefinitionsAndNoDefaultsSet(): void
+    public function testReturnEmptyArrayWhenLoadDefaultAndNoDefaultsSet(): void
     {
         $tag = TagBlock::tag();
 

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -6,6 +6,7 @@ namespace UIAwesome\Html\Core\Tests\Element;
 
 use LogicException;
 use PHPForge\Support\LineEndingNormalizer;
+use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -13,7 +14,13 @@ use UIAwesome\Html\Attribute\Values\{Aria, ContentEditable, Data, Direction, Dra
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Factory\SimpleFactory;
-use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagBlock, TagInline};
+use UIAwesome\Html\Core\Tests\Support\Stub\{
+    DefaultProvider,
+    DefaultThemeProvider,
+    TagBlock,
+    TagBlockWithDefaults,
+    TagInline,
+};
 use UIAwesome\Html\Interop\Block;
 
 /**
@@ -487,6 +494,20 @@ final class TagBlockTest extends TestCase
         );
     }
 
+    public function testRenderWithLoadDefaultDefinitions(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <div class="default-class">
+            </div>
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagBlockWithDefaults::tag()->render(),
+            ),
+            'Failed asserting that default definitions are applied correctly.',
+        );
+    }
+
     public function testRenderWithNestedBeginEnd(): void
     {
         self::assertEquals(
@@ -696,6 +717,16 @@ final class TagBlockTest extends TestCase
         self::assertEmpty(
             $tag->getDefaults($tag),
             'Failed asserting that getting defaults returns an empty array when no defaults are set.',
+        );
+    }
+
+    public function testReturnEmptyArrayWhenLoadDefaultDefinitionsAndNoDefaultsSet(): void
+    {
+        $tag = TagBlock::tag();
+
+        self::assertEmpty(
+            ReflectionHelper::invokeMethod($tag, 'loadDefault'),
+            'Failed asserting that loading default definitions returns an empty array when no defaults are set.',
         );
     }
 

--- a/tests/Support/Stub/TagBlockWithDefaults.php
+++ b/tests/Support/Stub/TagBlockWithDefaults.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Stub;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\Block;
+use UIAwesome\Html\Interop\BlockInterface;
+
+/**
+ * Stub for a block tag with default definitions.
+ *
+ * Supplies a {@see BaseBlock} implementation that provides default definitions via
+ * {@see TagBlockWithDefaults::loadDefaultDefinitions()}, supporting tests for default value
+ * application.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TagBlockWithDefaults extends BaseBlock
+{
+    /**
+     * Returns the tag enumeration for the `<div>` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<div>`.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return Block::DIV;
+    }
+
+    /**
+     * Returns default definitions for the tag.
+     *
+     * Provides default values that are applied when the tag is instantiated.
+     *
+     * @return array Default definitions.
+     *
+     * @phpstan-return mixed[]
+     */
+    protected function loadDefault(): array
+    {
+        return [
+            'class' => 'default-class',
+        ];
+    }
+}

--- a/tests/Support/Stub/TagBlockWithDefaults.php
+++ b/tests/Support/Stub/TagBlockWithDefaults.php
@@ -12,10 +12,9 @@ use UIAwesome\Html\Interop\BlockInterface;
  * Stub for a block tag with default definitions.
  *
  * Supplies a {@see BaseBlock} implementation that provides default definitions via
- * {@see TagBlockWithDefaults::loadDefaultDefinitions()}, supporting tests for default value
- * application.
+ * {@see TagBlockWithDefaults::loadDefault()}, supporting tests for default value application.
  *
- * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 final class TagBlockWithDefaults extends BaseBlock


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for class-level default configurations that are applied during tag creation.

* **Documentation**
  * Added a new subsection explaining class-level defaults, with examples and the configuration priority order (global, class, user).

* **Tests**
  * Added tests and a test stub to verify class-level default application and behavior when no defaults are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->