### PR TITLE
fix(tests): Update PHP version requirement in `BaseTagTest` from `8.4` to `8.5`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Dep #57: Update `ui-awesome/html-interop` requirement from `^0.2` to `^0.3` in `composer.json` (@terabytesoftw)
 - Enh #58: Add `loadDefault()` method in `BaseTag` class to provide default attribute values (@terabytesoftw)
+- Bug #59: Update PHP version requirement in `BaseTagTest` from `8.4` to `8.5` (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/tests/Base/BaseTagTest.php
+++ b/tests/Base/BaseTagTest.php
@@ -56,7 +56,7 @@ final class BaseTagTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('8.5')]
     public function testRenderBegin(): void
     {
         $tag = new class extends BaseTag {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
