### PR TITLE
feat(element): Add `BaseInput` class for HTML input elements with common attributes, methods and fix prefix/suffix rendering to support block, inline and void tags in `BaseInline`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Dep #57: Update `ui-awesome/html-interop` requirement from `^0.2` to `^0.3` in `composer.json` (@terabytesoftw)
 - Enh #58: Add `loadDefault()` method in `BaseTag` class to provide default attribute values (@terabytesoftw)
 - Bug #59: Update PHP version requirement in `BaseTagTest` from `8.4` to `8.5` (@terabytesoftw)
+- Enh #60: Add `BaseInput` class for HTML input elements with common attributes, methods and fix prefix/suffix rendering to support block, inline and void tags in `BaseInline` (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "ui-awesome/html-attribute": "^0.5",
+        "ui-awesome/html-attribute": "^0.6@dev",
         "ui-awesome/html-helper": "^0.6",
         "ui-awesome/html-interop": "^0.3",
         "ui-awesome/html-mixin": "^0.3"

--- a/src/Base/BaseTag.php
+++ b/src/Base/BaseTag.php
@@ -384,9 +384,9 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
      *
      * Override this method in subclasses to provide class specific default values.
      *
-     * @return array<string, mixed> Cookbook style configuration array.
+     * @return array Cookbook style configuration array.
      *
-     * @phpstan-return mixed[]
+     * @phpstan-return array<string, mixed>
      *
      * Usage example:
      * ```php

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -122,7 +122,7 @@ abstract class BaseInline extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -164,7 +164,7 @@ abstract class BaseInput extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -656,6 +656,7 @@ final class TagInlineTest extends TestCase
             "Failed asserting that element renders correctly with 'tabindex' attribute.",
         );
     }
+
     public function testRenderWithTemplateFallbackWhenTemplateEmpty(): void
     {
         self::assertEquals(

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -4,58 +4,37 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Element;
 
-use LogicException;
 use PHPForge\Support\LineEndingNormalizer;
 use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Values\{
-    Aria,
-    ContentEditable,
-    Data,
-    Direction,
-    Draggable,
-    Event,
-    Language,
-    Role,
-    Translate,
-};
-use UIAwesome\Html\Core\Exception\Message;
+use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, Language, Role, Translate};
 use UIAwesome\Html\Core\Factory\SimpleFactory;
-use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagInline};
+use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagInput};
 use UIAwesome\Html\Interop\{Block, Inline, Voids};
 
 /**
- * Unit tests for {@see TagInline} element rendering and attribute handling.
+ * Unit tests for {@see TagInput} element rendering.
  *
- * Verifies rendered output, provider application, and prefix/suffix rendering behavior for {@see TagInline}.
+ * Verifies rendered output for input elements including global attributes and prefix/suffix composition using block,
+ * inline and void tags.
  *
- * Test coverage.
- * - Applies default and theme providers.
- * - Renders inline elements with representative global HTML attributes.
- * - Renders prefix and suffix content with and without wrapper tags.
- * - Throws exceptions for unsupported `begin()`/`end()` usage.
- * - Uses `SimpleFactory` defaults while preserving user overrides.
+ * {@see TagInput} for element implementation details.
  *
- * {@see TagInline} for element implementation details.
- * {@see DefaultProvider} for default provider implementation.
- * {@see DefaultThemeProvider} for theme provider implementation.
- * {@see SimpleFactory} for default configuration management.
- *
- * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('element')]
-final class TagInlineTest extends TestCase
+final class TagInputTest extends TestCase
 {
     public function testRenderWithAccesskey(): void
     {
         self::assertEquals(
             <<<HTML
-            <span accesskey="k"></span>
+            <input accesskey="k">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->accesskey('k')->render(),
+                TagInput::tag()->accesskey('k')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
         );
@@ -65,10 +44,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span aria-pressed="true"></span>
+            <input aria-pressed="true">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addAriaAttribute('pressed', true)->render(),
+                TagInput::tag()->addAriaAttribute('pressed', true)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
@@ -78,10 +57,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span aria-pressed="true"></span>
+            <input aria-pressed="true">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+                TagInput::tag()->addAriaAttribute(Aria::PRESSED, true)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
         );
@@ -91,10 +70,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span data-value="value"></span>
+            <input data-value="value">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addDataAttribute('value', 'value')->render(),
+                TagInput::tag()->addDataAttribute('value', 'value')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
@@ -104,10 +83,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span data-value="value"></span>
+            <input data-value="value">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
+                TagInput::tag()->addDataAttribute(Data::VALUE, 'value')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
@@ -117,30 +96,32 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span onclick="handleClick()"></span>
+            <input onclick="handleClick()">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addEvent(Event::CLICK, 'handleClick()')->render(),
+                TagInput::tag()->addEvent(Event::CLICK, 'handleClick()')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
-    public function testRenderWithAriaAttribute(): void
+    public function testRenderWithAriaAttributes(): void
     {
         self::assertEquals(
             <<<HTML
-            <span aria-controls="modal-1" aria-hidden="false" aria-label="Close"></span>
+            <input aria-label="Close" aria-hidden="false" aria-controls="modal-1">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
                     ->ariaAttributes(
                         [
-                            'controls' => static fn(): string => 'modal-1',
-                            'hidden' => false,
                             'label' => 'Close',
+                            'hidden' => false,
+                            'controls' => static fn(): string => 'modal-1',
                         ],
-                    )->render(),
+                    )
+                    ->id(null)
+                    ->render(),
             ),
             "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
@@ -150,10 +131,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span class="test-class"></span>
+            <input class="test-class">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->attributes(['class' => 'test-class'])->render(),
+                TagInput::tag()->attributes(['class' => 'test-class'])->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'attributes()' method.",
         );
@@ -163,51 +144,12 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span class="test-class"></span>
+            <input class="test-class">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test-class')->render(),
+                TagInput::tag()->class('test-class')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'class' attribute.",
-        );
-    }
-
-    public function testRenderWithContent(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span>Content</span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->content('Content')->render(),
-            ),
-            "Failed asserting that element renders correctly with 'content()' method.",
-        );
-    }
-
-    public function testRenderWithContentEditable(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span contenteditable="true"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->contentEditable(true)->render(),
-            ),
-            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
-        );
-    }
-
-    public function testRenderWithContentEditableUsingEnum(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span contenteditable="true"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->contentEditable(ContentEditable::TRUE)->render(),
-            ),
-            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
         );
     }
 
@@ -215,23 +157,23 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span data-value="test-value"></span>
+            <input data-value="test-value">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->dataAttributes(['value' => 'test-value'])->render(),
+                TagInput::tag()->dataAttributes(['value' => 'test-value'])->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
         );
     }
 
-    public function testRenderWithDefaultConfigurationMethodValues(): void
+    public function testRenderWithDefaultConfigurationValues(): void
     {
         self::assertEquals(
             <<<HTML
-            <span class="default-class" title="default-title"></span>
+            <input class="default-class" title="default-title">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
+                TagInput::tag(['class' => 'default-class', 'title' => 'default-title'])->id(null)->render(),
             ),
             'Failed asserting that default configuration values are applied correctly.',
         );
@@ -241,10 +183,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span class="default-provider"></span>
+            <input class="default-provider">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->addDefaultProvider(DefaultProvider::class)->render(),
+                TagInput::tag()->addDefaultProvider(DefaultProvider::class)->id(null)->render(),
             ),
             'Failed asserting that default provider is applied correctly.',
         );
@@ -252,11 +194,11 @@ final class TagInlineTest extends TestCase
 
     public function testRenderWithDefaultValues(): void
     {
-        $instance = TagInline::tag();
+        $instance = TagInput::tag()->id(null);
 
         self::assertEquals(
             <<<HTML
-            <span></span>
+            <input>
             HTML,
             LineEndingNormalizer::normalize(
                 $instance->render(),
@@ -269,10 +211,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span dir="rtl"></span>
+            <input dir="rtl">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->dir('rtl')->render(),
+                TagInput::tag()->dir('rtl')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'dir' attribute.",
         );
@@ -282,38 +224,25 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span dir="rtl"></span>
+            <input dir="ltr">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->dir(Direction::RTL)->render(),
+                TagInput::tag()->dir(Direction::LTR)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
-    public function testRenderWithDraggable(): void
+    public function testRenderWithDisabled(): void
     {
         self::assertEquals(
             <<<HTML
-            <span draggable="true"></span>
+            <input disabled>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->draggable(true)->render(),
+                TagInput::tag()->disabled(true)->id(null)->render(),
             ),
-            "Failed asserting that element renders correctly with 'draggable' attribute.",
-        );
-    }
-
-    public function testRenderWithDraggableUsingEnum(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span draggable="true"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->draggable(Draggable::TRUE)->render(),
-            ),
-            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
         );
     }
 
@@ -321,33 +250,55 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span onchange="handleChange()"></span>
+            <input onchange="handleChange()">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->events(['change' => 'handleChange()'])->render(),
+                TagInput::tag()->events(['change' => 'handleChange()'])->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'events()' method.",
         );
     }
 
+    public function testRenderWithForm(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input form="signup-form">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->form('signup-form')->id(null)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGenerateId(): void
+    {
+        self::assertStringContainsString(
+            'id="taginput-',
+            TagInput::tag()->render(),
+            "Failed asserting that element generates an 'id' attribute when none is provided.",
+        );
+    }
+
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        $previous = SimpleFactory::getDefaults(TagInline::class);
+        $previous = SimpleFactory::getDefaults(TagInput::class);
 
         try {
-            SimpleFactory::setDefaults(TagInline::class, ['class' => 'from-global']);
+            SimpleFactory::setDefaults(TagInput::class, ['class' => 'from-global']);
 
             self::assertEquals(
                 <<<HTML
-                <span class="from-global"></span>
+                <input class="from-global">
                 HTML,
                 LineEndingNormalizer::normalize(
-                    TagInline::tag()->render(),
+                    TagInput::tag()->id(null)->render(),
                 ),
                 'Failed asserting that global defaults are applied correctly.',
             );
         } finally {
-            SimpleFactory::setDefaults(TagInline::class, $previous);
+            SimpleFactory::setDefaults(TagInput::class, $previous);
         }
     }
 
@@ -355,10 +306,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span hidden></span>
+            <input hidden>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->hidden(true)->render(),
+                TagInput::tag()->hidden(true)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
         );
@@ -368,77 +319,12 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span id="test-id"></span>
+            <input id="test-id">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->id('test-id')->render(),
+                TagInput::tag()->id('test-id')->render(),
             ),
             "Failed asserting that element renders correctly with 'id' attribute.",
-        );
-    }
-
-    public function testRenderWithItemId(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span itemid="http://example.com/item"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemId('http://example.com/item')->render(),
-            ),
-            "Failed asserting that element renders correctly with 'itemId' attribute.",
-        );
-    }
-
-    public function testRenderWithItemProp(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span itemprop="name"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemProp('name')->render(),
-            ),
-            "Failed asserting that element renders correctly with 'itemProp' attribute.",
-        );
-    }
-
-    public function testRenderWithItemRef(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span itemref="additional-info"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemRef('additional-info')->render(),
-            ),
-            "Failed asserting that element renders correctly with 'itemRef' attribute.",
-        );
-    }
-
-    public function testRenderWithItemScope(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span itemscope></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemScope(true)->render(),
-            ),
-            "Failed asserting that element renders correctly with 'itemScope' attribute.",
-        );
-    }
-
-    public function testRenderWithItemType(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span itemtype="http://schema.org/Person"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemType('http://schema.org/Person')->render(),
-            ),
-            "Failed asserting that element renders correctly with 'itemType' attribute.",
         );
     }
 
@@ -446,10 +332,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span lang="es"></span>
+            <input lang="es">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->lang('es')->render(),
+                TagInput::tag()->lang('es')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'lang' attribute.",
         );
@@ -459,10 +345,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span lang="es"></span>
+            <input lang="es">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->lang(Language::SPANISH)->render(),
+                TagInput::tag()->lang(Language::SPANISH)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'lang' attribute using enum.",
         );
@@ -470,11 +356,44 @@ final class TagInlineTest extends TestCase
 
     public function testRenderWithLoadDefault(): void
     {
-        $tag = TagInline::tag();
+        $tag = TagInput::tag();
 
-        self::assertEmpty(
-            ReflectionHelper::invokeMethod($tag, 'loadDefault'),
-            'Failed asserting that loading default definitions returns an empty array when no defaults are set.',
+        $defaults = ReflectionHelper::invokeMethod($tag, 'loadDefault');
+
+        self::assertIsArray(
+            $defaults,
+            "Failed asserting that 'loadDefault()' method returns an array.",
+        );
+        self::assertIsArray(
+            $defaults['id'] ?? null,
+            "Failed asserting that default 'id' is an array in 'loadDefault()' method.",
+        );
+        self::assertIsString(
+            $defaults['id'][0] ?? null,
+            "Failed asserting that default 'id' template is a string in 'loadDefault()' method.",
+        );
+        self::assertStringContainsString(
+            'taginput-',
+            $defaults['id'][0],
+            "Failed asserting that default 'id' is generated correctly in 'loadDefault()' method.",
+        );
+        self::assertSame(
+            ['{prefix}\n{tag}\n{suffix}'],
+            $defaults['template'] ?? [],
+            'Failed asserting that default definitions are applied correctly.',
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input name="username">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->name('username')->id(null)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'name' attribute.",
         );
     }
 
@@ -483,12 +402,12 @@ final class TagInlineTest extends TestCase
         self::assertEquals(
             <<<HTML
             <strong>Prefix</strong>
-            <span>Content</span>
+            <input>
             <em>Suffix</em>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->content('Content')
+                TagInput::tag()
+                    ->id(null)
                     ->prefix('Prefix')
                     ->prefixTag(Inline::STRONG)
                     ->suffix('Suffix')
@@ -504,10 +423,10 @@ final class TagInlineTest extends TestCase
         self::assertEquals(
             <<<HTML
             Prefix content
-            <span class="test"></span>
+            <input class="test">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test')->prefix('Prefix content')->render(),
+                TagInput::tag()->class('test')->prefix('Prefix content')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'prefix()' method.",
         );
@@ -520,13 +439,15 @@ final class TagInlineTest extends TestCase
             <div class="prefix-class" id="prefix-id">
             Prefix content
             </div>
-            <span></span>
+            <input>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->prefix('Prefix content')
+                TagInput::tag()
+                    ->prefix('Prefix content')
                     ->prefixAttributes(['id' => 'prefix-id'])
                     ->prefixClass('prefix-class')
                     ->prefixTag(Block::DIV)
+                    ->id(null)
                     ->render(),
             ),
             "Failed asserting that element renders correctly with 'prefixTag()' method using a block tag.",
@@ -538,13 +459,15 @@ final class TagInlineTest extends TestCase
         self::assertEquals(
             <<<HTML
             <strong class="prefix-class" id="prefix-id">Prefix content</strong>
-            <span></span>
+            <input>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->prefix('Prefix content')
+                TagInput::tag()
+                    ->prefix('Prefix content')
                     ->prefixAttributes(['id' => 'prefix-id'])
                     ->prefixClass('prefix-class')
                     ->prefixTag(Inline::STRONG)
+                    ->id(null)
                     ->render(),
             ),
             "Failed asserting that element renders correctly with 'prefixTag()' method.",
@@ -555,10 +478,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span role="button"></span>
+            <input role="button">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->role('button')->render(),
+                TagInput::tag()->role('button')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'role' attribute.",
         );
@@ -568,10 +491,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span role="button"></span>
+            <input role="button">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->role(Role::BUTTON)->render(),
+                TagInput::tag()->role(Role::BUTTON)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
@@ -581,10 +504,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span style='test-value'></span>
+            <input style='test-value'>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->style('test-value')->render(),
+                TagInput::tag()->style('test-value')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'style' attribute.",
         );
@@ -594,11 +517,11 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span class="test"></span>
+            <input class="test">
             Suffix content
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test')->suffix('Suffix content')->render(),
+                TagInput::tag()->class('test')->suffix('Suffix content')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'suffix()' method.",
         );
@@ -608,17 +531,18 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span></span>
+            <input>
             <div class="suffix-class" id="suffix-id">
             Suffix content
             </div>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
                     ->suffix('Suffix content')
                     ->suffixAttributes(['id' => 'suffix-id'])
                     ->suffixClass('suffix-class')
                     ->suffixTag(Block::DIV)
+                    ->id(null)
                     ->render(),
             ),
             "Failed asserting that element renders correctly with 'suffixTag()' method using a block tag.",
@@ -629,31 +553,19 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span></span>
+            <input>
             <strong class="suffix-class" id="suffix-id">Suffix content</strong>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
                     ->suffix('Suffix content')
                     ->suffixAttributes(['id' => 'suffix-id'])
                     ->suffixClass('suffix-class')
                     ->suffixTag(Inline::STRONG)
+                    ->id(null)
                     ->render(),
             ),
             "Failed asserting that element renders correctly with 'suffixTag()' method.",
-        );
-    }
-
-    public function testRenderWithTabindex(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span tabindex="3"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->tabIndex(3)->render(),
-            ),
-            "Failed asserting that element renders correctly with 'tabindex' attribute.",
         );
     }
     public function testRenderWithTemplateFallbackWhenTemplateEmpty(): void
@@ -661,14 +573,14 @@ final class TagInlineTest extends TestCase
         self::assertEquals(
             <<<HTML
             Prefix content
-            <span>Content</span>
+            <input>
             Suffix content
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
+                    ->id(null)
                     ->template('')
                     ->prefix('Prefix content')
-                    ->content('Content')
                     ->suffix('Suffix content')
                     ->render(),
             ),
@@ -676,42 +588,16 @@ final class TagInlineTest extends TestCase
         );
     }
 
-    public function testRenderWithThemeProvider(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span class="text-muted"></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
-            ),
-            'Failed asserting that theme provider is applied correctly.',
-        );
-    }
-
     public function testRenderWithTitle(): void
     {
         self::assertEquals(
             <<<HTML
-            <span title="test-value"></span>
+            <input title="test-value">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->title('test-value')->render(),
+                TagInput::tag()->title('test-value')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'title' attribute.",
-        );
-    }
-
-    public function testRenderWithToString(): void
-    {
-        self::assertEquals(
-            <<<HTML
-            <span></span>
-            HTML,
-            LineEndingNormalizer::normalize(
-                (string) TagInline::tag(),
-            ),
-            "Failed asserting that '__toString()' method renders correctly.",
         );
     }
 
@@ -719,10 +605,10 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span translate="no"></span>
+            <input translate="no">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->translate('no')->render(),
+                TagInput::tag()->translate('no')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
@@ -732,33 +618,46 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span translate="no"></span>
+            <input translate="yes">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()->translate(Translate::NO)->render(),
+                TagInput::tag()->translate(Translate::YES)->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 
+    public function testRenderWithType(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input type="text">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->type('text')->id(null)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'type' attribute.",
+        );
+    }
+
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        $previous = SimpleFactory::getDefaults(TagInline::class);
+        $previous = SimpleFactory::getDefaults(TagInput::class);
 
         try {
-            SimpleFactory::setDefaults(TagInline::class, ['class' => 'from-global', 'id' => 'id-global']);
+            SimpleFactory::setDefaults(TagInput::class, ['class' => 'from-global', 'id' => 'id-global']);
 
             self::assertEquals(
                 <<<HTML
-                <span class="from-global" id="id-user"></span>
+                <input class="from-global" id="id-user">
                 HTML,
                 LineEndingNormalizer::normalize(
-                    TagInline::tag()->id('id-user')->render(),
+                    TagInput::tag(['id' => 'id-user'])->render(),
                 ),
                 'Failed asserting that user-defined attributes override global defaults correctly.',
             );
         } finally {
-            SimpleFactory::setDefaults(TagInline::class, $previous);
+            SimpleFactory::setDefaults(TagInput::class, $previous);
         }
     }
 
@@ -767,10 +666,11 @@ final class TagInlineTest extends TestCase
         self::assertEquals(
             <<<HTML
             <img src="icon.svg" alt="Icon">
-            <span></span>
+            <input>
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
+                    ->id(null)
                     ->prefixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
                     ->prefixTag(Voids::IMG)
                     ->render(),
@@ -783,11 +683,12 @@ final class TagInlineTest extends TestCase
     {
         self::assertEquals(
             <<<HTML
-            <span></span>
+            <input>
             <img src="icon.svg" alt="Icon">
             HTML,
             LineEndingNormalizer::normalize(
-                TagInline::tag()
+                TagInput::tag()
+                    ->id(null)
                     ->suffixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
                     ->suffixTag(Voids::IMG)
                     ->render(),
@@ -798,7 +699,7 @@ final class TagInlineTest extends TestCase
 
     public function testReturnEmptyArrayWhenApplyThemeAndUndefinedTheme(): void
     {
-        $tag = TagInline::tag();
+        $tag = TagInput::tag();
 
         self::assertEmpty(
             $tag->apply($tag, ''),
@@ -808,31 +709,11 @@ final class TagInlineTest extends TestCase
 
     public function testReturnEmptyArrayWhenGetDefaultsAndNoDefaultsSet(): void
     {
-        $tag = TagInline::tag();
+        $tag = TagInput::tag();
 
         self::assertEmpty(
             $tag->getDefaults($tag),
             'Failed asserting that getting defaults returns an empty array when no defaults are set.',
         );
-    }
-
-    public function testThrowLogicExceptionForBeginCalled(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
-            Message::TAG_DOES_NOT_SUPPORT_BEGIN->getMessage(TagInline::class),
-        );
-
-        TagInline::tag()->begin();
-    }
-
-    public function testThrowLogicExceptionForEndCalled(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
-            Message::UNEXPECTED_END_CALL_NO_BEGIN->getMessage(TagInline::class),
-        );
-
-        TagInline::tag()::end();
     }
 }

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -568,6 +568,7 @@ final class TagInputTest extends TestCase
             "Failed asserting that element renders correctly with 'suffixTag()' method.",
         );
     }
+
     public function testRenderWithTemplateFallbackWhenTemplateEmpty(): void
     {
         self::assertEquals(

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -473,5 +473,4 @@ final class TagVoidTest extends TestCase
             'Failed asserting that getting defaults returns an empty array when no defaults are set.',
         );
     }
-
 }

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Element;
 
 use PHPForge\Support\LineEndingNormalizer;
+use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction};
-use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagVoid};
+use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, Language, Role, Translate};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagVoid};
 
 /**
  * Unit tests for {@see TagVoid} element rendering and attribute handling.
@@ -50,7 +52,7 @@ final class TagVoidTest extends TestCase
             LineEndingNormalizer::normalize(
                 TagVoid::tag()->addAriaAttribute('pressed', true)->render(),
             ),
-            "Failed asserting that element renders correctly with 'ariaAttribute()' method.",
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
     }
 
@@ -90,6 +92,19 @@ final class TagVoidTest extends TestCase
                 TagVoid::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
             ),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr onclick="handleClick()">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->addEvent(Event::CLICK, 'handleClick()')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
@@ -218,6 +233,40 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithEvents(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr onchange="handleChange()">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->events(['change' => 'handleChange()'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'events()' method.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        $previous = SimpleFactory::getDefaults(TagVoid::class);
+
+        try {
+            SimpleFactory::setDefaults(TagVoid::class, ['class' => 'from-global']);
+
+            self::assertEquals(
+                <<<HTML
+                <hr class="from-global">
+                HTML,
+                LineEndingNormalizer::normalize(
+                    TagVoid::tag()->render(),
+                ),
+                'Failed asserting that global defaults are applied correctly.',
+            );
+        } finally {
+            SimpleFactory::setDefaults(TagVoid::class, $previous);
+        }
+    }
+
     public function testRenderWithHidden(): void
     {
         self::assertEquals(
@@ -257,6 +306,29 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr lang="es">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->lang(Language::SPANISH)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithLoadDefault(): void
+    {
+        $tag = TagVoid::tag();
+
+        self::assertEmpty(
+            ReflectionHelper::invokeMethod($tag, 'loadDefault'),
+            'Failed asserting that loading default definitions returns an empty array when no defaults are set.',
+        );
+    }
+
     public function testRenderWithRole(): void
     {
         self::assertEquals(
@@ -267,6 +339,19 @@ final class TagVoidTest extends TestCase
                 TagVoid::tag()->role('generic')->render(),
             ),
             "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr role="button">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->role(Role::BUTTON)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
@@ -283,6 +368,19 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr class="text-muted">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            ),
+            'Failed asserting that theme provider is applied correctly.',
+        );
+    }
+
     public function testRenderWithTitle(): void
     {
         self::assertEquals(
@@ -296,6 +394,19 @@ final class TagVoidTest extends TestCase
         );
     }
 
+    public function testRenderWithToString(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr>
+            HTML,
+            LineEndingNormalizer::normalize(
+                (string) TagVoid::tag(),
+            ),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
     public function testRenderWithTranslate(): void
     {
         self::assertEquals(
@@ -303,9 +414,64 @@ final class TagVoidTest extends TestCase
             <hr translate="no">
             HTML,
             LineEndingNormalizer::normalize(
-                TagVoid::tag()->translate('no')->render(),
+                TagVoid::tag()->translate(false)->render(),
             ),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <hr translate="no">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagVoid::tag()->translate(Translate::NO)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        $previous = SimpleFactory::getDefaults(TagVoid::class);
+
+        try {
+            SimpleFactory::setDefaults(TagVoid::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+            self::assertEquals(
+                <<<HTML
+                <hr class="from-global" id="id-user">
+                HTML,
+                LineEndingNormalizer::normalize(
+                    TagVoid::tag(['id' => 'id-user'])->render(),
+                ),
+                'Failed asserting that user-defined attributes override global defaults correctly.',
+            );
+        } finally {
+            SimpleFactory::setDefaults(TagVoid::class, $previous);
+        }
+    }
+
+    public function testReturnEmptyArrayWhenApplyThemeAndUndefinedTheme(): void
+    {
+        $tag = TagVoid::tag();
+
+        self::assertEmpty(
+            $tag->apply($tag, ''),
+            'Failed asserting that applying an undefined theme returns an empty array.',
+        );
+    }
+
+    public function testReturnEmptyArrayWhenGetDefaultsAndNoDefaultsSet(): void
+    {
+        $tag = TagVoid::tag();
+
+        self::assertEmpty(
+            $tag->getDefaults($tag),
+            'Failed asserting that getting defaults returns an empty array when no defaults are set.',
+        );
+    }
+
 }

--- a/tests/Support/Stub/TagBlockWithDefaults.php
+++ b/tests/Support/Stub/TagBlockWithDefaults.php
@@ -36,7 +36,7 @@ final class TagBlockWithDefaults extends BaseBlock
      *
      * @return array Default definitions.
      *
-     * @phpstan-return mixed[]
+     * @phpstan-return array<string, mixed>
      */
     protected function loadDefault(): array
     {

--- a/tests/Support/Stub/TagInput.php
+++ b/tests/Support/Stub/TagInput.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Stub;
+
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Stub for an input tag implementation.
+ *
+ * Supplies a minimal {@see BaseInput} implementation that always resolves to the `<input>` tag, supporting
+ * deterministic assertions in unit tests involving input element rendering.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TagInput extends BaseInput
+{
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement();
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added input element base class with common attributes and methods
  * Enhanced rendering support for block, inline, and void tag types in prefix/suffix elements

* **Bug Fixes**
  * Fixed prefix/suffix tag rendering to properly handle different tag types

* **Tests**
  * Added comprehensive test coverage for input rendering and event handling

* **Chores**
  * Updated HTML attribute package dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->