### PR TITLE
fix(docs): Correct parameter order in docblocks for `BaseInput` and `BaseInline` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #58: Add `loadDefault()` method in `BaseTag` class to provide default attribute values (@terabytesoftw)
 - Bug #59: Update PHP version requirement in `BaseTagTest` from `8.4` to `8.5` (@terabytesoftw)
 - Enh #60: Add `BaseInput` class for HTML input elements with common attributes, methods and fix prefix/suffix rendering to support block, inline and void tags in `BaseInline` (@terabytesoftw)
+- Bug #61: Correct parameter order in docblocks for `BaseInput` and `BaseInline` classes (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -133,7 +133,7 @@ abstract class BaseInline extends BaseTag
      * @phpstan-return string
      */
     private function renderTag(
-        false|BlockInterface|InlineInterface|VoidInterface $tag,
+        BlockInterface|false|InlineInterface|VoidInterface $tag,
         string $content,
         array $attributes = [],
     ): string {

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -122,7 +122,7 @@ abstract class BaseInline extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -122,7 +122,7 @@ abstract class BaseInline extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -175,7 +175,7 @@ abstract class BaseInput extends BaseTag
      * @phpstan-return string
      */
     private function renderTag(
-        false|BlockInterface|InlineInterface|VoidInterface $tag,
+        BlockInterface|false|InlineInterface|VoidInterface $tag,
         string $content,
         array $attributes = [],
     ): string {

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -128,7 +128,7 @@ abstract class BaseInput extends BaseTag
     {
         $tokenTemplateValues = [
             '{prefix}' => $this->renderTag($this->prefixTag, $this->prefix, $this->prefixAttributes),
-            '{tag}' => $this->renderTag($this->getTag(), '', $this->getAttributes()),
+            '{tag}' => $this->renderTag($this->getTag(), (string) $content, $this->getAttributes()),
             '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
         ];
 
@@ -164,7 +164,7 @@ abstract class BaseInput extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -164,7 +164,7 @@ abstract class BaseInput extends BaseTag
     /**
      * Renders a tag or returns the content if the tag is not specified.
      *
-     * @param false|BlockInterface|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
+     * @param BlockInterface|false|InlineInterface|VoidInterface $tag Tag instance or `false` to skip rendering.
      * @param string $content Content to be rendered inside the tag.
      * @param array $attributes HTML attributes for the tag.
      *


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
