### PR TITLE
fix(element): Use `HasName` trait in `BaseInput` class to manage the `name` attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #60: Add `BaseInput` class for HTML input elements with common attributes, methods and fix prefix/suffix rendering to support block, inline and void tags in `BaseInline` (@terabytesoftw)
 - Bug #61: Correct parameter order in docblocks for `BaseInput` and `BaseInline` classes (@terabytesoftw)
 - Bug #62: Reorder use statements in `BaseInput` class for better organization (@terabytesoftw)
+- Bug #63: Use `HasName` trait in `BaseInput` class to manage the `name` attribute (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -21,14 +21,12 @@ use UIAwesome\Html\Attribute\Global\{
     HasTitle,
     HasTranslate,
 };
-use UIAwesome\Html\Attribute\{HasDisabled, HasType};
-use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Attribute\{HasDisabled, HasName, HasType};
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Helper\{Naming, Template};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UIAwesome\Html\Mixin\{HasAttributes, HasPrefixCollection, HasSuffixCollection, HasTemplate};
-use UnitEnum;
 
 /**
  * Abstract base class for HTML input element components.
@@ -66,6 +64,7 @@ abstract class BaseInput extends BaseTag
     use HasForm;
     use HasId;
     use HasLang;
+    use HasName;
     use HasPrefixCollection;
     use HasRole;
     use HasStyle;
@@ -91,21 +90,6 @@ abstract class BaseInput extends BaseTag
      * ```
      */
     abstract protected function getTag(): VoidInterface;
-
-    /**
-     * Sets the HTML `name` attribute for the input element.
-     *
-     * Note: The HTML `name` attribute for `<input>` elements is not limited to the set of standard metadata names used
-     * by `<meta>`.
-     *
-     * @param string|Stringable|UnitEnum|null $value Name value to set for the input element. Can be `null` to unset.
-     *
-     * @return static New instance with the updated `name` attribute.
-     */
-    public function name(string|Stringable|UnitEnum|null $value): static
-    {
-        return $this->addAttribute(Attribute::NAME, $value);
-    }
 
     /**
      * Builds the input element using the provided content and token values.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
