### PR TITLE
feat(element); Add support for automatic `aria-describedby` attribute in `BaseInput` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #61: Correct parameter order in docblocks for `BaseInput` and `BaseInline` classes (@terabytesoftw)
 - Bug #62: Reorder use statements in `BaseInput` class for better organization (@terabytesoftw)
 - Bug #63: Use `HasName` trait in `BaseInput` class to manage the `name` attribute (@terabytesoftw)
+- Enh #64: Add support for automatic `aria-describedby` attribute in `BaseInput` class (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -98,9 +98,8 @@ abstract class BaseInput extends BaseTag
      * attributes.
      *
      * @param string|Stringable $content Content to be rendered inside the tag.
-     *
-     * Note: The `<input>` element is a void element and does not render inner content.
-     * Use attributes such as `value` to configure the input's value.
+     * Note: The `<input>` element is a void element and does not render inner content. Use attributes such as `value`
+     * to configure the input's value.
      * @param array $tokenValues Additional token values for template rendering.
      *
      * @return string Rendered HTML for the inline element.
@@ -111,9 +110,18 @@ abstract class BaseInput extends BaseTag
      */
     protected function buildElement(string|Stringable $content = '', array $tokenValues = []): string
     {
+        $attributes = $this->getAttributes();
+
+        /** @phpstan-var string|null $id */
+        $id = $this->getAttribute('id', null);
+
+        if ($this->getAttribute('aria-describedby', null) === true && $id !== null) {
+            $attributes['aria-describedby'] = "{$id}-help";
+        }
+
         $tokenTemplateValues = [
             '{prefix}' => $this->renderTag($this->prefixTag, $this->prefix, $this->prefixAttributes),
-            '{tag}' => $this->renderTag($this->getTag(), (string) $content, $this->getAttributes()),
+            '{tag}' => $this->renderTag($this->getTag(), (string) $content, $attributes),
             '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
         ];
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -114,9 +114,10 @@ abstract class BaseInput extends BaseTag
 
         /** @phpstan-var string|null $id */
         $id = $this->getAttribute('id', null);
+        $ariaDescribedBy = $this->getAttribute('aria-describedby', null);
 
-        if ($this->getAttribute('aria-describedby', null) === true && $id !== null) {
-            $attributes['aria-describedby'] = "{$id}-help";
+        if ($ariaDescribedBy === true) {
+            $attributes['aria-describedby'] = $id !== null ? "{$id}-help" : null;
         }
 
         $tokenTemplateValues = [

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -127,6 +127,41 @@ final class TagInputTest extends TestCase
         );
     }
 
+    public function testRenderWithAriaDescribedByTrue(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input id="test-id" aria-describedby="test-id-help">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->id('test-id')->attributes(['aria-describedby' => true])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true.",
+        );
+    }
+
+    public function testRenderWithAriaDescribedByTrueAndPrefixSuffix(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="test-id" aria-describedby="test-id-help">
+            <span>Suffix</span>
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()
+                    ->id('test-id')
+                    ->attributes(['aria-describedby' => true])
+                    ->prefix('Prefix')
+                    ->prefixTag(Inline::SPAN)
+                    ->suffix('Suffix')
+                    ->suffixTag(Inline::SPAN)
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true and prefix/suffix.",
+        );
+    }
+
     public function testRenderWithAttributes(): void
     {
         self::assertEquals(

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -140,6 +140,19 @@ final class TagInputTest extends TestCase
         );
     }
 
+    public function testRenderWithAriaDescribedByTrueAndIdNull(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input>
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->id(null)->attributes(['aria-describedby' => true])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true and 'id' is null.",
+        );
+    }
+
     public function testRenderWithAriaDescribedByTrueAndPrefixSuffix(): void
     {
         self::assertEquals(

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -127,6 +127,19 @@ final class TagInputTest extends TestCase
         );
     }
 
+    public function testRenderWithAriaDescribedByString(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input id="test-id" aria-describedby="custom-help">
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInput::tag()->id('test-id')->attributes(['aria-describedby' => 'custom-help'])->render(),
+            ),
+            "Failed asserting that an explicit 'aria-describedby' string value is preserved.",
+        );
+    }
+
     public function testRenderWithAriaDescribedByTrue(): void
     {
         self::assertEquals(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
