### PR TITLE
feat(tests): Add stubs for `TagInline` and `TagInput` with token values for template rendering tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bug #62: Reorder use statements in `BaseInput` class for better organization (@terabytesoftw)
 - Bug #63: Use `HasName` trait in `BaseInput` class to manage the `name` attribute (@terabytesoftw)
 - Enh #64: Add support for automatic `aria-describedby` attribute in `BaseInput` class (@terabytesoftw)
+- Enh #65: Add stubs for `TagInline` and `TagInput` with token values for template rendering tests (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -109,14 +109,13 @@ abstract class BaseInline extends BaseTag
             '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
         ];
 
-        $tokenTemplateValues += $tokenValues;
-        $template = $this->template;
+        $template = $this->getTemplate();
 
         if ($template === '') {
             $template = '{prefix}\n{tag}\n{suffix}';
         }
 
-        return Template::render($template, $tokenTemplateValues);
+        return Template::render($template, [...$tokenTemplateValues, ...$tokenValues]);
     }
 
     /**

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -126,14 +126,13 @@ abstract class BaseInput extends BaseTag
             '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
         ];
 
-        $tokenTemplateValues += $tokenValues;
-        $template = $this->template;
+        $template = $this->getTemplate();
 
         if ($template === '') {
             $template = '{prefix}\n{tag}\n{suffix}';
         }
 
-        return Template::render($template, $tokenTemplateValues);
+        return Template::render($template, [...$tokenTemplateValues, ...$tokenValues]);
     }
 
     /**

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Element;
 
 use LogicException;
-use PHPForge\Support\LineEndingNormalizer;
-use PHPForge\Support\ReflectionHelper;
+use PHPForge\Support\{LineEndingNormalizer, ReflectionHelper};
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{
@@ -22,7 +21,7 @@ use UIAwesome\Html\Attribute\Values\{
 };
 use UIAwesome\Html\Core\Exception\Message;
 use UIAwesome\Html\Core\Factory\SimpleFactory;
-use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagInline};
+use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider, TagInline, TagInlineWithTokenValues};
 use UIAwesome\Html\Interop\{Block, Inline, Voids};
 
 /**
@@ -208,6 +207,24 @@ final class TagInlineTest extends TestCase
                 TagInline::tag()->contentEditable(ContentEditable::TRUE)->render(),
             ),
             "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithCustomTokenValues(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <span>Test content</span>
+            <div class="custom-token">Custom content from token</div>
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInlineWithTokenValues::tag()
+                    ->content('Test content')
+                    ->template('{tag}\n{custom}')
+                    ->tokenValues(['{custom}' => '<div class="custom-token">Custom content from token</div>'])
+                    ->render(),
+            ),
+            'Failed asserting that element renders correctly with custom token values spread into template.',
         );
     }
 

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Element;
 
-use PHPForge\Support\LineEndingNormalizer;
-use PHPForge\Support\ReflectionHelper;
+use PHPForge\Support\{LineEndingNormalizer, ReflectionHelper};
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, Language, Role, Translate};
 use UIAwesome\Html\Core\Factory\SimpleFactory;
-use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagInput};
+use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagInput, TagInputWithTokenValues};
 use UIAwesome\Html\Interop\{Block, Inline, Voids};
 
 /**
@@ -211,6 +210,24 @@ final class TagInputTest extends TestCase
                 TagInput::tag()->class('test-class')->id(null)->render(),
             ),
             "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithCustomTokenValues(): void
+    {
+        self::assertEquals(
+            <<<HTML
+            <input id="test-id">
+            <span class="custom-token">Custom content from token</span>
+            HTML,
+            LineEndingNormalizer::normalize(
+                TagInputWithTokenValues::tag()
+                    ->id('test-id')
+                    ->template('{tag}\n{custom}')
+                    ->tokenValues(['{custom}' => '<span class="custom-token">Custom content from token</span>'])
+                    ->render(),
+            ),
+            'Failed asserting that element renders correctly with custom token values spread into template.',
         );
     }
 

--- a/tests/Support/Stub/TagInlineWithTokenValues.php
+++ b/tests/Support/Stub/TagInlineWithTokenValues.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Stub;
+
+use UIAwesome\Html\Core\Element\BaseInline;
+use UIAwesome\Html\Interop\{Inline, InlineInterface};
+
+/**
+ * Stub for inline tag that exposes `buildElement()` with `tokenValues` parameter.
+ *
+ * Used to test the spread operator behavior in {@see BaseInline::buildElement()} when merging token template values
+ * with additional token values.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TagInlineWithTokenValues extends BaseInline
+{
+    /**
+     * Additional token values to pass to {@see BaseInline::buildElement()}
+     *
+     * @phpstan-var mixed[]
+     */
+    private array $tokenValues = [];
+
+    /**
+     * Sets additional token values for template rendering.
+     *
+     * @param array $tokenValues Additional token values.
+     *
+     * @return static New instance with the updated `tokenValues` value.
+     *
+     * @phpstan-param mixed[] $tokenValues
+     */
+    public function tokenValues(array $tokenValues): static
+    {
+        $new = clone $this;
+        $new->tokenValues = $tokenValues;
+
+        return $new;
+    }
+
+    /**
+     * Returns the tag enumeration for the `<span>` element.
+     *
+     * @return InlineInterface Tag enumeration instance for `<span>`.
+     */
+    protected function getTag(): InlineInterface
+    {
+        return Inline::SPAN;
+    }
+
+    /**
+     * Renders the `<span>` element with its content, attributes and token values.
+     *
+     * @return string Rendered HTML for the `<span>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement($this->getContent(), $this->tokenValues);
+    }
+}

--- a/tests/Support/Stub/TagInputWithTokenValues.php
+++ b/tests/Support/Stub/TagInputWithTokenValues.php
@@ -19,7 +19,7 @@ use UIAwesome\Html\Interop\{VoidInterface, Voids};
 final class TagInputWithTokenValues extends BaseInput
 {
     /**
-     * @var array Additional token values to pass to {@see BaseInline::buildElement()}.
+     * Additional token values to pass to {@see BaseInput::buildElement()}.
      *
      * @phpstan-var mixed[]
      */

--- a/tests/Support/Stub/TagInputWithTokenValues.php
+++ b/tests/Support/Stub/TagInputWithTokenValues.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Tests\Support\Stub;
+
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Stub for input tag that exposes `buildElement()` with `tokenValues` parameter.
+ *
+ * Used to test the spread operator behavior in {@see BaseInput::buildElement()} when merging token template values
+ * with additional token values.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TagInputWithTokenValues extends BaseInput
+{
+    /**
+     * @var array Additional token values to pass to {@see BaseInline::buildElement()}.
+     *
+     * @phpstan-var mixed[]
+     */
+    private array $tokenValues = [];
+
+    /**
+     * Sets additional token values for template rendering.
+     *
+     * @param array $tokenValues Additional token values.
+     *
+     * @return static New instance with the updated `tokenValues` value.
+     *
+     * @phpstan-param mixed[] $tokenValues
+     */
+    public function tokenValues(array $tokenValues): static
+    {
+        $new = clone $this;
+        $new->tokenValues = $tokenValues;
+
+        return $new;
+    }
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes and token values.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement('', $this->tokenValues);
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
