### PR TITLE
refactor(element): Replace direct property access with getter methods for `prefix` and `suffix` in `BaseInput` and `BaseInline` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bug #63: Use `HasName` trait in `BaseInput` class to manage the `name` attribute (@terabytesoftw)
 - Enh #64: Add support for automatic `aria-describedby` attribute in `BaseInput` class (@terabytesoftw)
 - Enh #65: Add stubs for `TagInline` and `TagInput` with token values for template rendering tests (@terabytesoftw)
+- Bug #66: Replace direct property access with getter methods for `prefix` and `suffix` in `BaseInput` and `BaseInline` classes (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -104,9 +104,9 @@ abstract class BaseInline extends BaseTag
     protected function buildElement(string|Stringable $content = '', array $tokenValues = []): string
     {
         $tokenTemplateValues = [
-            '{prefix}' => $this->renderTag($this->prefixTag, $this->prefix, $this->prefixAttributes),
+            '{prefix}' => $this->renderTag($this->getPrefixTag(), $this->getPrefix(), $this->getPrefixAttributes()),
             '{tag}' => $this->renderTag($this->getTag(), (string) $content, $this->getAttributes()),
-            '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
+            '{suffix}' => $this->renderTag($this->getSuffixTag(), $this->getSuffix(), $this->getSuffixAttributes()),
         ];
 
         $template = $this->getTemplate();

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -121,9 +121,9 @@ abstract class BaseInput extends BaseTag
         }
 
         $tokenTemplateValues = [
-            '{prefix}' => $this->renderTag($this->prefixTag, $this->prefix, $this->prefixAttributes),
+            '{prefix}' => $this->renderTag($this->getPrefixTag(), $this->getPrefix(), $this->getPrefixAttributes()),
             '{tag}' => $this->renderTag($this->getTag(), (string) $content, $attributes),
-            '{suffix}' => $this->renderTag($this->suffixTag, $this->suffix, $this->suffixAttributes),
+            '{suffix}' => $this->renderTag($this->getSuffixTag(), $this->getSuffix(), $this->getSuffixAttributes()),
         ];
 
         $template = $this->getTemplate();


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
