### PR TITLE
refactor(element): Enhance HTML output formatting by adding line breaks using `PHP_EOL` const in `BaseHtml`, `BaseBlock`, `BaseInline`, and `BaseTag` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Enh #65: Add stubs for `TagInline` and `TagInput` with token values for template rendering tests (@terabytesoftw)
 - Bug #66: Replace direct property access with getter methods for `prefix` and `suffix` in `BaseInput` and `BaseInline` classes (@terabytesoftw)
 - Bug #67: Update condition for `aria-describedby` attribute in `BaseInput` class to accept string `true` (@terabytesoftw)
+- Bug #68: Enhance HTML output formatting by adding line breaks using `PHP_EOL` const in `BaseHtml`, `BaseBlock`, `BaseInline`, and `BaseTag` classes (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Base/BaseHtml.php
+++ b/src/Base/BaseHtml.php
@@ -8,6 +8,8 @@ use BackedEnum;
 use UIAwesome\Html\Helper\{Attributes, Encode};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 
+use const PHP_EOL;
+
 /**
  * Base class for HTML tag rendering and element generation.
  *
@@ -69,7 +71,7 @@ abstract class BaseHtml
     {
         $renderAttributes = Attributes::render($attributes);
 
-        return "<{$tag->value}{$renderAttributes}>\n";
+        return "<{$tag->value}{$renderAttributes}>" . PHP_EOL;
     }
 
     /**
@@ -122,10 +124,10 @@ abstract class BaseHtml
         $renderAttributes = Attributes::render($attributes);
 
         if ($content === '') {
-            return "<{$tag->value}{$renderAttributes}>\n</{$tag->value}>";
+            return "<{$tag->value}{$renderAttributes}>" . PHP_EOL . "</{$tag->value}>";
         }
 
-        return "<{$tag->value}{$renderAttributes}>\n{$content}\n</{$tag->value}>";
+        return "<{$tag->value}{$renderAttributes}>" . PHP_EOL . "{$content}" . PHP_EOL . "</{$tag->value}>";
     }
 
     /**
@@ -152,7 +154,7 @@ abstract class BaseHtml
      */
     public static function end(BlockInterface $tag): string
     {
-        return "\n</{$tag->value}>";
+        return PHP_EOL . "</{$tag->value}>";
     }
 
     /**

--- a/src/Base/BaseHtml.php
+++ b/src/Base/BaseHtml.php
@@ -8,8 +8,6 @@ use BackedEnum;
 use UIAwesome\Html\Helper\{Attributes, Encode};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 
-use const PHP_EOL;
-
 /**
  * Base class for HTML tag rendering and element generation.
  *
@@ -71,7 +69,7 @@ abstract class BaseHtml
     {
         $renderAttributes = Attributes::render($attributes);
 
-        return "<{$tag->value}{$renderAttributes}>" . PHP_EOL;
+        return "<{$tag->value}{$renderAttributes}>\n";
     }
 
     /**
@@ -124,10 +122,10 @@ abstract class BaseHtml
         $renderAttributes = Attributes::render($attributes);
 
         if ($content === '') {
-            return "<{$tag->value}{$renderAttributes}>" . PHP_EOL . "</{$tag->value}>";
+            return "<{$tag->value}{$renderAttributes}>\n</{$tag->value}>";
         }
 
-        return "<{$tag->value}{$renderAttributes}>" . PHP_EOL . "{$content}" . PHP_EOL . "</{$tag->value}>";
+        return "<{$tag->value}{$renderAttributes}>\n{$content}\n</{$tag->value}>";
     }
 
     /**
@@ -154,7 +152,7 @@ abstract class BaseHtml
      */
     public static function end(BlockInterface $tag): string
     {
-        return PHP_EOL . "</{$tag->value}>";
+        return "\n</{$tag->value}>";
     }
 
     /**

--- a/src/Base/BaseTag.php
+++ b/src/Base/BaseTag.php
@@ -396,7 +396,7 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
      *
      *     return [
      *         'id()' => [Utils::generateId("$shortClassName-")],
-     *         'template()' => ['{prefix}\n{tag}\n{suffix}'],
+     *         'template()' => ['{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}'],
      *     ];
      * }
      * ```

--- a/src/Base/BaseTag.php
+++ b/src/Base/BaseTag.php
@@ -396,7 +396,7 @@ abstract class BaseTag implements DefaultsProviderInterface, ThemeProviderInterf
      *
      *     return [
      *         'id()' => [Utils::generateId("$shortClassName-")],
-     *         'template()' => ['{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}'],
+     *         'template()' => ["{prefix}\n{tag}\n{suffix}"],
      *     ];
      * }
      * ```

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -30,8 +30,6 @@ use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Interop\BlockInterface;
 use UIAwesome\Html\Mixin\{HasAttributes, HasContent};
 
-use function preg_replace;
-
 /**
  * Base class for constructing block-level HTML elements.
  *
@@ -94,22 +92,6 @@ abstract class BaseBlock extends BaseTag
      * ```
      */
     abstract protected function getTag(): BlockInterface;
-
-    /**
-     * Cleans up the output after rendering the block element.
-     *
-     * Removes excessive consecutive newlines from the rendered output to ensure clean HTML structure.
-     *
-     * @param string $result Rendered HTML output.
-     *
-     * @return string Cleaned HTML output with excessive newlines removed.
-     */
-    protected function afterRun(string $result): string
-    {
-        $normalizeOutput = preg_replace("/\n{2,}/", "\n", $result) ?? '';
-
-        return parent::afterRun($normalizeOutput);
-    }
 
     /**
      * Renders the block element.

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -26,8 +26,6 @@ use UIAwesome\Html\Helper\Template;
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UIAwesome\Html\Mixin\{HasAttributes, HasContent, HasPrefixCollection, HasSuffixCollection, HasTemplate};
 
-use const PHP_EOL;
-
 /**
  * Base class for constructing inline-level HTML elements.
  *
@@ -114,7 +112,7 @@ abstract class BaseInline extends BaseTag
         $template = $this->getTemplate();
 
         if ($template === '') {
-            $template = '{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}';
+            $template = "{prefix}\n{tag}\n{suffix}";
         }
 
         return Template::render($template, [...$tokenTemplateValues, ...$tokenValues]);

--- a/src/Element/BaseInline.php
+++ b/src/Element/BaseInline.php
@@ -26,6 +26,8 @@ use UIAwesome\Html\Helper\Template;
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UIAwesome\Html\Mixin\{HasAttributes, HasContent, HasPrefixCollection, HasSuffixCollection, HasTemplate};
 
+use const PHP_EOL;
+
 /**
  * Base class for constructing inline-level HTML elements.
  *
@@ -112,7 +114,7 @@ abstract class BaseInline extends BaseTag
         $template = $this->getTemplate();
 
         if ($template === '') {
-            $template = '{prefix}\n{tag}\n{suffix}';
+            $template = '{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}';
         }
 
         return Template::render($template, [...$tokenTemplateValues, ...$tokenValues]);

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -28,8 +28,6 @@ use UIAwesome\Html\Helper\{Naming, Template};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UIAwesome\Html\Mixin\{HasAttributes, HasPrefixCollection, HasSuffixCollection, HasTemplate};
 
-use const PHP_EOL;
-
 /**
  * Abstract base class for HTML input element components.
  *
@@ -131,7 +129,7 @@ abstract class BaseInput extends BaseTag
         $template = $this->getTemplate();
 
         if ($template === '') {
-            $template = '{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}';
+            $template = "{prefix}\n{tag}\n{suffix}";
         }
 
         return Template::render($template, [...$tokenTemplateValues, ...$tokenValues]);
@@ -152,7 +150,7 @@ abstract class BaseInput extends BaseTag
 
         return [
             'id' => [Naming::generateId("$shortClassName-")],
-            'template' => ['{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}'],
+            'template' => ["{prefix}\n{tag}\n{suffix}"],
         ];
     }
 

--- a/tests/Base/BaseTagTest.php
+++ b/tests/Base/BaseTagTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Base;
 
-use PHPForge\Support\LineEndingNormalizer;
 use PHPUnit\Framework\Attributes\{Group, RequiresPhp};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Base\BaseTag;
@@ -90,7 +89,7 @@ final class BaseTagTest extends TestCase
             Content
             </div>
             HTML,
-            LineEndingNormalizer::normalize($tag->begin() . 'Content' . $tag::end()),
+            $tag->begin() . 'Content' . $tag::end(),
             'Expected correct rendering of begin and end tags.',
         );
     }

--- a/tests/Element/TagBlockTest.php
+++ b/tests/Element/TagBlockTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Element;
 
 use LogicException;
-use PHPForge\Support\LineEndingNormalizer;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -44,7 +43,6 @@ use UIAwesome\Html\Interop\Block;
  * - Throws exceptions for invalid `begin()`/`end()` usage.
  * - Uses `SimpleFactory` defaults while preserving user overrides.
  *
- * {@see TagBlock} for element implementation details.
  * {@see DefaultProvider} for default provider implementation.
  * {@see DefaultThemeProvider} for theme provider implementation.
  * {@see SimpleFactory} for default configuration management.
@@ -57,501 +55,489 @@ final class TagBlockTest extends TestCase
 {
     public function testRenderWithAccesskey(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div accesskey="k">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->accesskey('k')->render(),
-            ),
+            TagBlock::tag()
+                ->accesskey('k')
+                ->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
         );
     }
 
     public function testRenderWithAddAriaAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div aria-pressed="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addAriaAttribute('pressed', true)->render(),
-            ),
+            TagBlock::tag()
+                ->addAriaAttribute('pressed', true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
     }
 
     public function testRenderWithAddAriaAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div aria-pressed="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
-            ),
+            TagBlock::tag()
+                ->addAriaAttribute(Aria::PRESSED, true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
     }
 
     public function testRenderWithAddDataAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div data-value="value">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addDataAttribute('value', 'value')->render(),
-            ),
+            TagBlock::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
     }
 
     public function testRenderWithAddDataAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div data-value="value">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
-            ),
+            TagBlock::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
     }
 
     public function testRenderWithAddEvent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div onclick="handleClick()">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addEvent(Event::CLICK, 'handleClick()')->render(),
-            ),
+            TagBlock::tag()
+                ->addEvent(Event::CLICK, 'handleClick()')
+                ->render(),
             "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
     public function testRenderWithAriaAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div aria-controls="modal-1" aria-hidden="false" aria-label="Close">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->ariaAttributes(
+            TagBlock::tag()
+                ->ariaAttributes(
                     [
                         'controls' => static fn(): string => 'modal-1',
                         'hidden' => false,
                         'label' => 'Close',
                     ],
-                )->render(),
-            ),
+                )
+                ->render(),
             "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
     }
 
     public function testRenderWithAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="test-class">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->attributes(['class' => 'test-class'])->render(),
-            ),
+            TagBlock::tag()
+                ->attributes(['class' => 'test-class'])
+                ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
         );
     }
 
     public function testRenderWithAutofocus(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div autofocus>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->autofocus(true)->render(),
-            ),
+            TagBlock::tag()
+                ->autofocus(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'autofocus' attribute.",
         );
     }
 
     public function testRenderWithBeginEnd(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             Content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->begin() . 'Content' . TagBlock::end(),
-            ),
+            TagBlock::tag()->begin() . 'Content' . TagBlock::end(),
             "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
         );
     }
 
     public function testRenderWithClass(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="test-class">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->class('test-class')->render(),
-            ),
+            TagBlock::tag()
+                ->class('test-class')
+                ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
         );
     }
 
     public function testRenderWithContent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             Content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->content('Content')->render(),
-            ),
+            TagBlock::tag()
+                ->content('Content')
+                ->render(),
             "Failed asserting that element renders correctly with 'content()' method.",
         );
     }
 
     public function testRenderWithContentEditable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div contenteditable="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->contentEditable(true)->render(),
-            ),
+            TagBlock::tag()
+                ->contentEditable(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute.",
         );
     }
 
     public function testRenderWithContentEditableUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div contenteditable="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->contentEditable(ContentEditable::TRUE)->render(),
-            ),
+            TagBlock::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
         );
     }
 
     public function testRenderWithDataAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div data-value="test-value">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->dataAttributes(['value' => 'test-value'])->render(),
-            ),
+            TagBlock::tag()
+                ->dataAttributes(['value' => 'test-value'])
+                ->render(),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
         );
     }
 
     public function testRenderWithDefaultConfigurationValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="default-class" title="default-title">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
-            ),
+            TagBlock::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }
 
     public function testRenderWithDefaultProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="default-provider">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addDefaultProvider(DefaultProvider::class)->render(),
-            ),
+            TagBlock::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
             'Failed asserting that default provider is applied correctly.',
         );
     }
 
     public function testRenderWithDefaultValues(): void
     {
-        $instance = TagBlock::tag();
-
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                $instance->render(),
-            ),
+            TagBlock::tag()->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
 
     public function testRenderWithDir(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div dir="rtl">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->dir('rtl')->render(),
-            ),
+            TagBlock::tag()->dir('rtl')->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
         );
     }
 
     public function testRenderWithDirUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div dir="rtl">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->dir(Direction::RTL)->render(),
-            ),
+            TagBlock::tag()
+                ->dir(Direction::RTL)
+                ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
     public function testRenderWithDraggable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div draggable="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->draggable(true)->render(),
-            ),
+            TagBlock::tag()
+                ->draggable(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
         );
     }
 
     public function testRenderWithDraggableUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div draggable="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->draggable(Draggable::TRUE)->render(),
-            ),
+            TagBlock::tag()
+                ->draggable(Draggable::TRUE)
+                ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
         );
     }
 
     public function testRenderWithEvents(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div onchange="handleChange()">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->events(['change' => 'handleChange()'])->render(),
-            ),
+            TagBlock::tag()
+                ->events(['change' => 'handleChange()'])
+                ->render(),
             "Failed asserting that element renders correctly with 'events()' method.",
         );
     }
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        $previous = SimpleFactory::getDefaults(TagBlock::class);
+        SimpleFactory::setDefaults(
+            TagBlock::class,
+            ['class' => 'from-global'],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagBlock::class, ['class' => 'from-global']);
+        self::assertSame(
+            <<<HTML
+            <div class="from-global">
+            </div>
+            HTML,
+            TagBlock::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <div class="from-global">
-                </div>
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagBlock::tag()->render(),
-                ),
-                'Failed asserting that global defaults are applied correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagBlock::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagBlock::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div hidden>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->hidden(true)->render(),
-            ),
+            TagBlock::tag()
+                ->hidden(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
         );
     }
 
     public function testRenderWithId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <div id="test-id">
+            <div id="tagblock">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->id('test-id')->render(),
-            ),
+            TagBlock::tag()
+                ->id('tagblock')
+                ->render(),
             "Failed asserting that element renders correctly with 'id' attribute.",
         );
     }
 
     public function testRenderWithItemId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div itemid="http://example.com/item">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->itemId('http://example.com/item')->render(),
-            ),
+            TagBlock::tag()
+                ->itemId('http://example.com/item')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemId' attribute.",
         );
     }
 
     public function testRenderWithItemProp(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div itemprop="name">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->itemProp('name')->render(),
-            ),
+            TagBlock::tag()
+                ->itemProp('name')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemProp' attribute.",
         );
     }
 
     public function testRenderWithItemRef(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div itemref="additional-info">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->itemRef('additional-info')->render(),
-            ),
+            TagBlock::tag()
+                ->itemRef('additional-info')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemRef' attribute.",
         );
     }
 
     public function testRenderWithItemScope(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div itemscope>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->itemScope(true)->render(),
-            ),
+            TagBlock::tag()
+                ->itemScope(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'itemScope' attribute.",
         );
     }
 
     public function testRenderWithItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div itemtype="http://schema.org/Person">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->itemType('http://schema.org/Person')->render(),
-            ),
+            TagBlock::tag()
+                ->itemType('http://schema.org/Person')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemType' attribute.",
         );
     }
 
     public function testRenderWithLang(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div lang="es">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->lang('es')->render(),
-            ),
+            TagBlock::tag()
+                ->lang('es')
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
         );
     }
 
     public function testRenderWithLangUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div lang="es">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->lang(Language::SPANISH)->render(),
-            ),
+            TagBlock::tag()
+                ->lang(Language::SPANISH)
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute using enum.",
         );
     }
 
     public function testRenderWithLoadDefault(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="default-class">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlockWithDefaults::tag()->render(),
-            ),
+            TagBlockWithDefaults::tag()->render(),
             'Failed asserting that default definitions are applied correctly.',
         );
     }
 
     public function testRenderWithNestedBeginEnd(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             <div>
@@ -559,190 +545,185 @@ final class TagBlockTest extends TestCase
             </div>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->begin() . TagBlock::tag()->begin() . 'Nested Content' . TagBlock::end() . TagBlock::end(),
-            ),
+            TagBlock::tag()->begin() . TagBlock::tag()->begin() . 'Nested Content' . TagBlock::end() . TagBlock::end(),
             "Failed asserting that nested elements render correctly with 'begin()' and 'end()' methods.",
         );
     }
 
     public function testRenderWithNestedDifferentTagsEnsuresStackUpdate(): void
     {
-        $html = TagBlock::tag()->begin() . TagInline::tag()->content('Content')->render() . TagBlock::end();
-
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             <span>Content</span>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                $html,
-            ),
+            TagBlock::tag()->begin() . TagInline::tag()->content('Content')->render() . TagBlock::end(),
             'Failed asserting that nested different tags render correctly and stack is updated.',
         );
     }
 
     public function testRenderWithRole(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div role="banner">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->role('banner')->render(),
-            ),
+            TagBlock::tag()
+                ->role('banner')
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
         );
     }
 
     public function testRenderWithRoleUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div role="banner">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->role(Role::BANNER)->render(),
-            ),
+            TagBlock::tag()
+                ->role(Role::BANNER)
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
     public function testRenderWithSpellcheck(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div spellcheck="true">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->spellcheck(true)->render(),
-            ),
+            TagBlock::tag()
+                ->spellcheck(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'spellcheck' attribute.",
         );
     }
 
     public function testRenderWithStyle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div style='test-value'>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->style('test-value')->render(),
-            ),
+            TagBlock::tag()
+                ->style('test-value')
+                ->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",
         );
     }
 
     public function testRenderWithTabindex(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div tabindex="3">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->tabIndex(3)->render(),
-            ),
+            TagBlock::tag()
+                ->tabIndex(3)
+                ->render(),
             "Failed asserting that element renders correctly with 'tabindex' attribute.",
         );
     }
 
     public function testRenderWithThemeProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="tag-primary">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->addThemeProvider('primary', DefaultThemeProvider::class)->render(),
-            ),
+            TagBlock::tag()
+                ->addThemeProvider('primary', DefaultThemeProvider::class)
+                ->render(),
             'Failed asserting that theme provider is applied correctly.',
         );
     }
 
     public function testRenderWithTitle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div title="test-value">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->title('test-value')->render(),
-            ),
+            TagBlock::tag()
+                ->title('test-value')
+                ->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }
 
     public function testRenderWithToString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                (string) TagBlock::tag(),
-            ),
+            (string) TagBlock::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
 
     public function testRenderWithTranslate(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div translate="no">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->translate(false)->render(),
-            ),
+            TagBlock::tag()
+                ->translate(false)
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 
     public function testRenderWithTranslateUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div translate="yes">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagBlock::tag()->translate(Translate::YES)->render(),
-            ),
+            TagBlock::tag()
+                ->translate(Translate::YES)
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        $previous = SimpleFactory::getDefaults(TagBlock::class);
+        SimpleFactory::setDefaults(
+            TagBlock::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagBlock::class, ['class' => 'from-global', 'id' => 'id-global']);
+        self::assertSame(
+            <<<HTML
+            <div class="from-global" id="id-user">
+            </div>
+            HTML,
+            TagBlock::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <div class="from-global" id="id-user">
-                </div>
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagBlock::tag(['id' => 'id-user'])->render(),
-                ),
-                'Failed asserting that user-defined attributes override global defaults correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagBlock::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagBlock::class,
+            [],
+        );
     }
 
     public function testReturnEmptyArrayWhenApplyThemeAndUndefinedTheme(): void
@@ -789,12 +770,11 @@ final class TagBlockTest extends TestCase
             }
         };
 
-        $tagClass = $tag::class;
         TagBlock::tag()->begin();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            Message::TAG_CLASS_MISMATCH_ON_END->getMessage(TagBlock::class, $tagClass),
+            Message::TAG_CLASS_MISMATCH_ON_END->getMessage(TagBlock::class, $tag::class),
         );
 
         $tag::end();

--- a/tests/Element/TagInlineTest.php
+++ b/tests/Element/TagInlineTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Core\Tests\Element;
 
 use LogicException;
-use PHPForge\Support\{LineEndingNormalizer, ReflectionHelper};
+use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{
@@ -49,438 +49,429 @@ final class TagInlineTest extends TestCase
 {
     public function testRenderWithAccesskey(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span accesskey="k"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->accesskey('k')->render(),
-            ),
+            TagInline::tag()
+                ->accesskey('k')
+                ->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
         );
     }
 
     public function testRenderWithAddAriaAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span aria-pressed="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addAriaAttribute('pressed', true)->render(),
-            ),
+            TagInline::tag()
+                ->addAriaAttribute('pressed', true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
     }
 
     public function testRenderWithAddAriaAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span aria-pressed="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
-            ),
+            TagInline::tag()
+                ->addAriaAttribute(Aria::PRESSED, true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
         );
     }
 
     public function testRenderWithAddDataAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span data-value="value"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addDataAttribute('value', 'value')->render(),
-            ),
+            TagInline::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
     }
 
     public function testRenderWithAddDataAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span data-value="value"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
-            ),
+            TagInline::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
     }
 
     public function testRenderWithAddEvent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span onclick="handleClick()"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addEvent(Event::CLICK, 'handleClick()')->render(),
-            ),
+            TagInline::tag()
+                ->addEvent(Event::CLICK, 'handleClick()')
+                ->render(),
             "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
     public function testRenderWithAriaAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span aria-controls="modal-1" aria-hidden="false" aria-label="Close"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->ariaAttributes(
-                        [
-                            'controls' => static fn(): string => 'modal-1',
-                            'hidden' => false,
-                            'label' => 'Close',
-                        ],
-                    )->render(),
-            ),
+            TagInline::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => static fn(): string => 'modal-1',
+                        'hidden' => false,
+                        'label' => 'Close',
+                    ],
+                )
+                ->render(),
             "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
     }
 
     public function testRenderWithAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span class="test-class"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->attributes(['class' => 'test-class'])->render(),
-            ),
+            TagInline::tag()
+                ->attributes(['class' => 'test-class'])
+                ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
         );
     }
 
     public function testRenderWithClass(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span class="test-class"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test-class')->render(),
-            ),
+            TagInline::tag()
+                ->class('test-class')
+                ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
         );
     }
 
     public function testRenderWithContent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span>Content</span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->content('Content')->render(),
-            ),
+            TagInline::tag()
+                ->content('Content')
+                ->render(),
             "Failed asserting that element renders correctly with 'content()' method.",
         );
     }
 
     public function testRenderWithContentEditable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span contenteditable="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->contentEditable(true)->render(),
-            ),
+            TagInline::tag()
+                ->contentEditable(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute.",
         );
     }
 
     public function testRenderWithContentEditableUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span contenteditable="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->contentEditable(ContentEditable::TRUE)->render(),
-            ),
+            TagInline::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
         );
     }
 
     public function testRenderWithCustomTokenValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span>Test content</span>
             <div class="custom-token">Custom content from token</div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInlineWithTokenValues::tag()
-                    ->content('Test content')
-                    ->template('{tag}\n{custom}')
-                    ->tokenValues(['{custom}' => '<div class="custom-token">Custom content from token</div>'])
-                    ->render(),
-            ),
+            TagInlineWithTokenValues::tag()
+                ->content('Test content')
+                ->template('{tag}\n{custom}')
+                ->tokenValues(['{custom}' => '<div class="custom-token">Custom content from token</div>'])
+                ->render(),
             'Failed asserting that element renders correctly with custom token values spread into template.',
         );
     }
 
     public function testRenderWithDataAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <span data-value="test-value"></span>
+            <span data-value="value"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->dataAttributes(['value' => 'test-value'])->render(),
-            ),
+            TagInline::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->render(),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
         );
     }
 
     public function testRenderWithDefaultConfigurationMethodValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span class="default-class" title="default-title"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
-            ),
+            TagInline::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }
 
     public function testRenderWithDefaultProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span class="default-provider"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addDefaultProvider(DefaultProvider::class)->render(),
-            ),
+            TagInline::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
             'Failed asserting that default provider is applied correctly.',
         );
     }
 
     public function testRenderWithDefaultValues(): void
     {
-        $instance = TagInline::tag();
-
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                $instance->render(),
-            ),
+            TagInline::tag()->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
 
     public function testRenderWithDir(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span dir="rtl"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->dir('rtl')->render(),
-            ),
+            TagInline::tag()
+                ->dir('rtl')
+                ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
         );
     }
 
     public function testRenderWithDirUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span dir="rtl"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->dir(Direction::RTL)->render(),
-            ),
+            TagInline::tag()
+                ->dir(Direction::RTL)
+                ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
     public function testRenderWithDraggable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span draggable="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->draggable(true)->render(),
-            ),
+            TagInline::tag()
+                ->draggable(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
         );
     }
 
     public function testRenderWithDraggableUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span draggable="true"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->draggable(Draggable::TRUE)->render(),
-            ),
+            TagInline::tag()
+                ->draggable(Draggable::TRUE)
+                ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
         );
     }
 
     public function testRenderWithEvents(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span onchange="handleChange()"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->events(['change' => 'handleChange()'])->render(),
-            ),
+            TagInline::tag()
+                ->events(['change' => 'handleChange()'])
+                ->render(),
             "Failed asserting that element renders correctly with 'events()' method.",
         );
     }
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        $previous = SimpleFactory::getDefaults(TagInline::class);
+        SimpleFactory::setDefaults(
+            TagInline::class,
+            ['class' => 'from-global'],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagInline::class, ['class' => 'from-global']);
+        self::assertSame(
+            <<<HTML
+            <span class="from-global"></span>
+            HTML,
+            TagInline::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <span class="from-global"></span>
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagInline::tag()->render(),
-                ),
-                'Failed asserting that global defaults are applied correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagInline::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagInline::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span hidden></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->hidden(true)->render(),
-            ),
+            TagInline::tag()
+                ->hidden(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
         );
     }
 
     public function testRenderWithId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <span id="test-id"></span>
+            <span id="taginline"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->id('test-id')->render(),
-            ),
+            TagInline::tag()
+                ->id('taginline')
+                ->render(),
             "Failed asserting that element renders correctly with 'id' attribute.",
         );
     }
 
     public function testRenderWithItemId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span itemid="http://example.com/item"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemId('http://example.com/item')->render(),
-            ),
+            TagInline::tag()
+                ->itemId('http://example.com/item')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemId' attribute.",
         );
     }
 
     public function testRenderWithItemProp(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span itemprop="name"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemProp('name')->render(),
-            ),
+            TagInline::tag()
+                ->itemProp('name')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemProp' attribute.",
         );
     }
 
     public function testRenderWithItemRef(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span itemref="additional-info"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemRef('additional-info')->render(),
-            ),
+            TagInline::tag()
+                ->itemRef('additional-info')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemRef' attribute.",
         );
     }
 
     public function testRenderWithItemScope(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span itemscope></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemScope(true)->render(),
-            ),
+            TagInline::tag()
+                ->itemScope(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'itemScope' attribute.",
         );
     }
 
     public function testRenderWithItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span itemtype="http://schema.org/Person"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->itemType('http://schema.org/Person')->render(),
-            ),
+            TagInline::tag()
+                ->itemType('http://schema.org/Person')
+                ->render(),
             "Failed asserting that element renders correctly with 'itemType' attribute.",
         );
     }
 
     public function testRenderWithLang(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span lang="es"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->lang('es')->render(),
-            ),
+            TagInline::tag()
+                ->lang('es')
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
         );
     }
 
     public function testRenderWithLangUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span lang="es"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->lang(Language::SPANISH)->render(),
-            ),
+            TagInline::tag()
+                ->lang(Language::SPANISH)
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute using enum.",
         );
     }
@@ -497,319 +488,308 @@ final class TagInlineTest extends TestCase
 
     public function testRenderWithPrefixAndSuffix(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <strong>Prefix</strong>
             <span>Content</span>
             <em>Suffix</em>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->content('Content')
-                    ->prefix('Prefix')
-                    ->prefixTag(Inline::STRONG)
-                    ->suffix('Suffix')
-                    ->suffixTag(Inline::EM)
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->content('Content')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::STRONG)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::EM)
+                ->render(),
             "Failed asserting that element renders correctly with both 'prefix()' and 'suffix()' methods.",
         );
     }
 
     public function testRenderWithPrefixSetWithoutPrefixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             Prefix content
-            <span class="test"></span>
+            <span class="value"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test')->prefix('Prefix content')->render(),
-            ),
+            TagInline::tag()
+                ->class('value')
+                ->prefix('Prefix content')
+                ->render(),
             "Failed asserting that element renders correctly with 'prefix()' method.",
         );
     }
 
     public function testRenderWithPrefixTagUsingBlockTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="prefix-class" id="prefix-id">
             Prefix content
             </div>
             <span></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->prefix('Prefix content')
-                    ->prefixAttributes(['id' => 'prefix-id'])
-                    ->prefixClass('prefix-class')
-                    ->prefixTag(Block::DIV)
-                    ->render(),
-            ),
+            TagInline::tag()->prefix('Prefix content')
+                ->prefixAttributes(['id' => 'prefix-id'])
+                ->prefixClass('prefix-class')
+                ->prefixTag(Block::DIV)
+                ->render(),
             "Failed asserting that element renders correctly with 'prefixTag()' method using a block tag.",
         );
     }
 
     public function testRenderWithPrefixTagWhenPrefixSet(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <strong class="prefix-class" id="prefix-id">Prefix content</strong>
             <span></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->prefix('Prefix content')
-                    ->prefixAttributes(['id' => 'prefix-id'])
-                    ->prefixClass('prefix-class')
-                    ->prefixTag(Inline::STRONG)
-                    ->render(),
-            ),
+            TagInline::tag()->prefix('Prefix content')
+                ->prefixAttributes(['id' => 'prefix-id'])
+                ->prefixClass('prefix-class')
+                ->prefixTag(Inline::STRONG)
+                ->render(),
             "Failed asserting that element renders correctly with 'prefixTag()' method.",
         );
     }
 
     public function testRenderWithRole(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span role="button"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->role('button')->render(),
-            ),
+            TagInline::tag()
+                ->role('button')
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
         );
     }
 
     public function testRenderWithRoleUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span role="button"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->role(Role::BUTTON)->render(),
-            ),
+            TagInline::tag()
+                ->role(Role::BUTTON)
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
     public function testRenderWithStyle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <span style='test-value'></span>
+            <span style='value'></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->style('test-value')->render(),
-            ),
+            TagInline::tag()
+                ->style('value')
+                ->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",
         );
     }
 
     public function testRenderWithSuffixSetWithoutSuffixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <span class="test"></span>
+            <span class="value"></span>
             Suffix content
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->class('test')->suffix('Suffix content')->render(),
-            ),
+            TagInline::tag()
+                ->class('value')
+                ->suffix('Suffix content')
+                ->render(),
             "Failed asserting that element renders correctly with 'suffix()' method.",
         );
     }
 
     public function testRenderWithSuffixTagUsingBlockTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span></span>
             <div class="suffix-class" id="suffix-id">
             Suffix content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->suffix('Suffix content')
-                    ->suffixAttributes(['id' => 'suffix-id'])
-                    ->suffixClass('suffix-class')
-                    ->suffixTag(Block::DIV)
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->suffix('Suffix content')
+                ->suffixAttributes(['id' => 'suffix-id'])
+                ->suffixClass('suffix-class')
+                ->suffixTag(Block::DIV)
+                ->render(),
             "Failed asserting that element renders correctly with 'suffixTag()' method using a block tag.",
         );
     }
 
     public function testRenderWithSuffixTagWhenSuffixSet(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span></span>
             <strong class="suffix-class" id="suffix-id">Suffix content</strong>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->suffix('Suffix content')
-                    ->suffixAttributes(['id' => 'suffix-id'])
-                    ->suffixClass('suffix-class')
-                    ->suffixTag(Inline::STRONG)
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->suffix('Suffix content')
+                ->suffixAttributes(['id' => 'suffix-id'])
+                ->suffixClass('suffix-class')
+                ->suffixTag(Inline::STRONG)
+                ->render(),
             "Failed asserting that element renders correctly with 'suffixTag()' method.",
         );
     }
 
     public function testRenderWithTabindex(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span tabindex="3"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->tabIndex(3)->render(),
-            ),
+            TagInline::tag()
+                ->tabIndex(3)
+                ->render(),
             "Failed asserting that element renders correctly with 'tabindex' attribute.",
         );
     }
 
     public function testRenderWithTemplateFallbackWhenTemplateEmpty(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             Prefix content
             <span>Content</span>
             Suffix content
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->template('')
-                    ->prefix('Prefix content')
-                    ->content('Content')
-                    ->suffix('Suffix content')
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->content('Content')
+                ->prefix('Prefix content')
+                ->suffix('Suffix content')
+                ->template('')
+                ->render(),
             "Failed asserting that element renders correctly when 'template()' is empty.",
         );
     }
 
     public function testRenderWithThemeProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span class="text-muted"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
-            ),
+            TagInline::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
             'Failed asserting that theme provider is applied correctly.',
         );
     }
 
     public function testRenderWithTitle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <span title="test-value"></span>
+            <span title="value"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->title('test-value')->render(),
-            ),
+            TagInline::tag()
+                ->title('value')
+                ->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }
 
     public function testRenderWithToString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                (string) TagInline::tag(),
-            ),
+            (string) TagInline::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
 
     public function testRenderWithTranslate(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span translate="no"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->translate('no')->render(),
-            ),
+            TagInline::tag()
+                ->translate('no')
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 
     public function testRenderWithTranslateUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span translate="no"></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()->translate(Translate::NO)->render(),
-            ),
+            TagInline::tag()
+                ->translate(Translate::NO)
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        $previous = SimpleFactory::getDefaults(TagInline::class);
+        SimpleFactory::setDefaults(
+            TagInline::class,
+            [
+                'class' => 'from-global',
+                'id' => 'taginline-id-global',
+            ],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagInline::class, ['class' => 'from-global', 'id' => 'id-global']);
+        self::assertSame(
+            <<<HTML
+            <span class="from-global" id="taginline-id-user"></span>
+            HTML,
+            TagInline::tag()
+                ->id('taginline-id-user')
+                ->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <span class="from-global" id="id-user"></span>
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagInline::tag()->id('id-user')->render(),
-                ),
-                'Failed asserting that user-defined attributes override global defaults correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagInline::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagInline::class,
+            [],
+        );
     }
 
     public function testRenderWithVoidPrefixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <img src="icon.svg" alt="Icon">
             <span></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->prefixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
-                    ->prefixTag(Voids::IMG)
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->prefixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
+                ->prefixTag(Voids::IMG)
+                ->render(),
             'Failed asserting that element renders correctly with a void prefix tag.',
         );
     }
 
     public function testRenderWithVoidSuffixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span></span>
             <img src="icon.svg" alt="Icon">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagInline::tag()
-                    ->suffixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
-                    ->suffixTag(Voids::IMG)
-                    ->render(),
-            ),
+            TagInline::tag()
+                ->suffixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
+                ->suffixTag(Voids::IMG)
+                ->render(),
             'Failed asserting that element renders correctly with a void suffix tag.',
         );
     }

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Element;
 
-use PHPForge\Support\{LineEndingNormalizer, ReflectionHelper};
+use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, Language, Role, Translate};
@@ -30,7 +30,7 @@ final class TagInputTest extends TestCase
 {
     public function testRenderWithAccesskey(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" accesskey="k">
             HTML,
@@ -44,7 +44,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-pressed="true">
             HTML,
@@ -58,7 +58,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-pressed="true">
             HTML,
@@ -72,7 +72,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="custom-help">
             HTML,
@@ -86,7 +86,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByTrueBooleanValue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -101,7 +101,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByTrueBooleanValueAndIdNull(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input>
             HTML,
@@ -116,7 +116,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByTrueBooleanValueAndPrefixSuffix(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span>Prefix</span>
             <input id="taginput" aria-describedby="taginput-help">
@@ -137,7 +137,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByTrueBooleanValueString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -152,7 +152,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddAriaDescribedByTrueStringValueAndPrefixSuffix(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span>Prefix</span>
             <input id="taginput" aria-describedby="taginput-help">
@@ -173,7 +173,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddDataAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" data-value="value">
             HTML,
@@ -187,7 +187,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddDataAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" data-value="value">
             HTML,
@@ -201,7 +201,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAddEvent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" onclick="handleClick()">
             HTML,
@@ -215,7 +215,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAriaAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-label="Close" aria-hidden="false" aria-controls="modal-1">
             HTML,
@@ -235,7 +235,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAriaAttributesAndAriaDescribedByTrueBooleanValue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -249,7 +249,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAriaAttributesAndAriaDescribedByTrueStringValue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -263,7 +263,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="value" id="taginput">
             HTML,
@@ -277,7 +277,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAttributesAndAriaDescribedByTrueBooleanValue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -291,7 +291,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithAttributesAndAriaDescribedByTrueStringValue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" aria-describedby="taginput-help">
             HTML,
@@ -305,7 +305,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithClass(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="value" id="taginput">
             HTML,
@@ -319,7 +319,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithCustomTokenValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput">
             <span class="custom-token">Custom content from token</span>
@@ -335,7 +335,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDataAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" data-value="test-value">
             HTML,
@@ -349,7 +349,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDefaultConfigurationValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="default-class" id="taginput" title="default-title">
             HTML,
@@ -362,7 +362,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDefaultProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="default-provider" id="taginput">
             HTML,
@@ -376,20 +376,20 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDefaultValues(): void
     {
-        $instance = TagInput::tag()->id(null);
-
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input>
             HTML,
-            $instance->render(),
+            TagInput::tag()
+                ->id(null)
+                ->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
 
     public function testRenderWithDir(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" dir="rtl">
             HTML,
@@ -403,7 +403,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDirUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" dir="ltr">
             HTML,
@@ -417,7 +417,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithDisabled(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" disabled>
             HTML,
@@ -431,7 +431,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithEvents(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" onchange="handleChange()">
             HTML,
@@ -445,7 +445,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithForm(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" form="signup-form">
             HTML,
@@ -475,12 +475,10 @@ final class TagInputTest extends TestCase
 
         SimpleFactory::setDefaults(
             TagInput::class,
-            [
-                'class' => 'from-global',
-            ],
+            ['class' => 'from-global'],
         );
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="from-global" id="taginput">
             HTML,
@@ -498,7 +496,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithHidden(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" hidden>
             HTML,
@@ -512,7 +510,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput">
             HTML,
@@ -525,7 +523,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithLang(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" lang="es">
             HTML,
@@ -539,7 +537,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithLangUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" lang="es">
             HTML,
@@ -583,7 +581,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithName(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" name="username">
             HTML,
@@ -597,7 +595,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithPrefixAndSuffix(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <strong>Prefix</strong>
             <input id="taginput">
@@ -616,7 +614,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithPrefixSetWithoutPrefixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             Prefix content
             <input class="test" id="taginput">
@@ -632,7 +630,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithPrefixTagUsingBlockTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="prefix-class" id="prefix-id">
             Prefix content
@@ -652,7 +650,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithPrefixTagWhenPrefixSet(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <strong class="prefix-class" id="prefix-id">Prefix content</strong>
             <input id="taginput">
@@ -670,7 +668,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithRole(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" role="button">
             HTML,
@@ -684,7 +682,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithRoleUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" role="button">
             HTML,
@@ -698,7 +696,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithStyle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" style='test-value'>
             HTML,
@@ -712,7 +710,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithSuffixSetWithoutSuffixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="test" id="taginput">
             Suffix content
@@ -728,7 +726,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithSuffixTagUsingBlockTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput">
             <div class="suffix-class" id="suffix-id">
@@ -748,7 +746,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithSuffixTagWhenSuffixSet(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput">
             <strong class="suffix-class" id="suffix-id">Suffix content</strong>
@@ -766,7 +764,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithTemplateFallbackWhenTemplateEmpty(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             Prefix content
             <input id="taginput">
@@ -784,7 +782,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithTitle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" title="test-value">
             HTML,
@@ -798,21 +796,18 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithToString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input>
             HTML,
-            LineEndingNormalizer::normalize(
-                (string) TagInput::tag()
-                    ->id(null),
-            ),
+            (string) TagInput::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
 
     public function testRenderWithTranslate(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" translate="no">
             HTML,
@@ -826,7 +821,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithTranslateUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" translate="yes">
             HTML,
@@ -840,7 +835,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input id="taginput" type="text">
             HTML,
@@ -864,7 +859,7 @@ final class TagInputTest extends TestCase
             ],
         );
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input class="from-global" id="id-user">
             HTML,
@@ -880,7 +875,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithVoidPrefixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <img src="icon.svg" alt="Icon">
             <input>
@@ -896,7 +891,7 @@ final class TagInputTest extends TestCase
 
     public function testRenderWithVoidSuffixTag(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <input>
             <img src="icon.svg" alt="Icon">

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -12,8 +12,6 @@ use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagInput, TagInputWithTokenValues};
 use UIAwesome\Html\Interop\{Block, Inline, Voids};
 
-use const PHP_EOL;
-
 /**
  * Unit tests for {@see TagInput} element rendering.
  *
@@ -326,7 +324,7 @@ final class TagInputTest extends TestCase
             HTML,
             TagInputWithTokenValues::tag()
                 ->id('taginput')
-                ->template('{tag}' . PHP_EOL . '{custom}')
+                ->template("{tag}\n{custom}")
                 ->tokenValues(['{custom}' => '<span class="custom-token">Custom content from token</span>'])
                 ->render(),
             'Failed asserting that element renders correctly with custom token values spread into template.',
@@ -573,7 +571,7 @@ final class TagInputTest extends TestCase
             "Failed asserting that default 'id' is generated correctly in 'loadDefault()' method.",
         );
         self::assertSame(
-            ['{prefix}' . PHP_EOL . '{tag}' . PHP_EOL . '{suffix}'],
+            ["{prefix}\n{tag}\n{suffix}"],
             $defaults['template'] ?? [],
             'Failed asserting that default definitions are applied correctly.',
         );

--- a/tests/Element/TagVoidTest.php
+++ b/tests/Element/TagVoidTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Element;
 
-use PHPForge\Support\LineEndingNormalizer;
 use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -32,426 +31,419 @@ final class TagVoidTest extends TestCase
 {
     public function testRenderWithAccesskey(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr accesskey="k">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->accesskey('k')->render(),
-            ),
+            TagVoid::tag()
+                ->accesskey('k')
+                ->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
         );
     }
 
     public function testRenderWithAddAriaAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr aria-pressed="true">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addAriaAttribute('pressed', true)->render(),
-            ),
+            TagVoid::tag()
+                ->addAriaAttribute('pressed', true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
     }
 
     public function testRenderWithAddAriaAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr aria-pressed="true">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
-            ),
+            TagVoid::tag()
+                ->addAriaAttribute(Aria::PRESSED, true)
+                ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
         );
     }
 
     public function testRenderWithAddDataAttribute(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr data-value="value">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addDataAttribute('value', 'value')->render(),
-            ),
+            TagVoid::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
     }
 
     public function testRenderWithAddDataAttributeUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr data-value="value">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
-            ),
+            TagVoid::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
     }
 
     public function testRenderWithAddEvent(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr onclick="handleClick()">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addEvent(Event::CLICK, 'handleClick()')->render(),
-            ),
+            TagVoid::tag()
+                ->addEvent(Event::CLICK, 'handleClick()')
+                ->render(),
             "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
     public function testRenderWithAriaAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr aria-label="Close" aria-hidden="false" aria-controls="modal-1">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->ariaAttributes(
+            TagVoid::tag()
+                ->ariaAttributes(
                     [
                         'label' => 'Close',
                         'hidden' => false,
                         'controls' => static fn(): string => 'modal-1',
                     ],
-                )->render(),
-            ),
+                )
+                ->render(),
             "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
     }
 
     public function testRenderWithAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr class="test-class">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->attributes(['class' => 'test-class'])->render(),
-            ),
+            TagVoid::tag()
+                ->attributes(['class' => 'test-class'])
+                ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
         );
     }
 
     public function testRenderWithClass(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr class="test-class">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->class('test-class')->render(),
-            ),
+            TagVoid::tag()
+                ->class('test-class')
+                ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
         );
     }
 
     public function testRenderWithDataAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr data-value="test-value">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->dataAttributes(['value' => 'test-value'])->render(),
-            ),
+            TagVoid::tag()
+                ->dataAttributes(['value' => 'test-value'])
+                ->render(),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
         );
     }
 
     public function testRenderWithDefaultConfigurationValues(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr class="default-class" title="default-title">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
-            ),
+            TagVoid::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }
 
     public function testRenderWithDefaultProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr class="default-provider">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addDefaultProvider(DefaultProvider::class)->render(),
-            ),
+            TagVoid::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
             'Failed asserting that default provider is applied correctly.',
         );
     }
 
     public function testRenderWithDefaultValues(): void
     {
-        $instance = TagVoid::tag();
-
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr>
             HTML,
-            LineEndingNormalizer::normalize(
-                $instance->render(),
-            ),
+            TagVoid::tag()->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
 
     public function testRenderWithDir(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr dir="rtl">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->dir('rtl')->render(),
-            ),
+            TagVoid::tag()
+                ->dir('rtl')
+                ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
         );
     }
 
     public function testRenderWithDirUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr dir="ltr">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->dir(Direction::LTR)->render(),
-            ),
+            TagVoid::tag()
+                ->dir(Direction::LTR)
+                ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
     }
 
     public function testRenderWithEvents(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr onchange="handleChange()">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->events(['change' => 'handleChange()'])->render(),
-            ),
+            TagVoid::tag()
+                ->events(['change' => 'handleChange()'])
+                ->render(),
             "Failed asserting that element renders correctly with 'events()' method.",
         );
     }
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        $previous = SimpleFactory::getDefaults(TagVoid::class);
+        SimpleFactory::setDefaults(
+            TagVoid::class,
+            ['class' => 'from-global'],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagVoid::class, ['class' => 'from-global']);
+        self::assertSame(
+            <<<HTML
+            <hr class="from-global">
+            HTML,
+            TagVoid::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <hr class="from-global">
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagVoid::tag()->render(),
-                ),
-                'Failed asserting that global defaults are applied correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagVoid::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagVoid::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr hidden>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->hidden(true)->render(),
-            ),
+            TagVoid::tag()
+                ->hidden(true)
+                ->render(),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
         );
     }
 
     public function testRenderWithId(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
-            <hr id="test-id">
+            <hr id="tagvoid">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->id('test-id')->render(),
-            ),
+            TagVoid::tag()
+                ->id('tagvoid')
+                ->render(),
             "Failed asserting that element renders correctly with 'id' attribute.",
         );
     }
 
     public function testRenderWithLang(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr lang="es">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->lang('es')->render(),
-            ),
+            TagVoid::tag()
+                ->lang('es')
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
         );
     }
 
     public function testRenderWithLangUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr lang="es">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->lang(Language::SPANISH)->render(),
-            ),
+            TagVoid::tag()
+                ->lang(Language::SPANISH)
+                ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute using enum.",
         );
     }
 
     public function testRenderWithLoadDefault(): void
     {
-        $tag = TagVoid::tag();
-
         self::assertEmpty(
-            ReflectionHelper::invokeMethod($tag, 'loadDefault'),
+            ReflectionHelper::invokeMethod(TagVoid::tag(), 'loadDefault'),
             'Failed asserting that loading default definitions returns an empty array when no defaults are set.',
         );
     }
 
     public function testRenderWithRole(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr role="generic">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->role('generic')->render(),
-            ),
+            TagVoid::tag()
+                ->role('generic')
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
         );
     }
 
     public function testRenderWithRoleUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr role="button">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->role(Role::BUTTON)->render(),
-            ),
+            TagVoid::tag()
+                ->role(Role::BUTTON)
+                ->render(),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }
 
     public function testRenderWithStyle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr style='test-value'>
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->style('test-value')->render(),
-            ),
+            TagVoid::tag()
+                ->style('test-value')
+                ->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",
         );
     }
 
     public function testRenderWithThemeProvider(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr class="text-muted">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
-            ),
+            TagVoid::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
             'Failed asserting that theme provider is applied correctly.',
         );
     }
 
     public function testRenderWithTitle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr title="test-value">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->title('test-value')->render(),
-            ),
+            TagVoid::tag()
+                ->title('test-value')
+                ->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }
 
     public function testRenderWithToString(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr>
             HTML,
-            LineEndingNormalizer::normalize(
-                (string) TagVoid::tag(),
-            ),
+            (string) TagVoid::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
 
     public function testRenderWithTranslate(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr translate="no">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->translate(false)->render(),
-            ),
+            TagVoid::tag()
+                ->translate(false)
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
 
     public function testRenderWithTranslateUsingEnum(): void
     {
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <hr translate="no">
             HTML,
-            LineEndingNormalizer::normalize(
-                TagVoid::tag()->translate(Translate::NO)->render(),
-            ),
+            TagVoid::tag()
+                ->translate(Translate::NO)
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
     }
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        $previous = SimpleFactory::getDefaults(TagVoid::class);
+        SimpleFactory::setDefaults(
+            TagVoid::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        try {
-            SimpleFactory::setDefaults(TagVoid::class, ['class' => 'from-global', 'id' => 'id-global']);
+        self::assertSame(
+            <<<HTML
+            <hr class="from-global" id="id-user">
+            HTML,
+            TagVoid::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-            self::assertEquals(
-                <<<HTML
-                <hr class="from-global" id="id-user">
-                HTML,
-                LineEndingNormalizer::normalize(
-                    TagVoid::tag(['id' => 'id-user'])->render(),
-                ),
-                'Failed asserting that user-defined attributes override global defaults correctly.',
-            );
-        } finally {
-            SimpleFactory::setDefaults(TagVoid::class, $previous);
-        }
+        SimpleFactory::setDefaults(
+            TagVoid::class,
+            [],
+        );
     }
 
     public function testReturnEmptyArrayWhenApplyThemeAndUndefinedTheme(): void

--- a/tests/Factory/SimpleFactoryTest.php
+++ b/tests/Factory/SimpleFactoryTest.php
@@ -36,20 +36,16 @@ final class SimpleFactoryTest extends TestCase
 {
     public function testCreateWithDefaultConfigurationPropertiesValues(): void
     {
-        $tag = TagInline::tag(['flag' => true]);
-
         self::assertTrue(
-            $tag->flag,
+            TagInline::tag(['flag' => true])->flag,
             'Failed asserting that factory creates instance with default configuration properties values.',
         );
     }
 
     public function testCreateWithoutConfigurationUsesDefaultValues(): void
     {
-        $tag = TagInline::tag();
-
         self::assertFalse(
-            $tag->flag,
+            TagInline::tag()->flag,
             'Failed asserting that factory creates instance with default property values.',
         );
     }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests;
 
-use PHPForge\Support\LineEndingNormalizer;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Html;
@@ -45,7 +44,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(BlockProvider::class, 'blockTags')]
     public function testRenderBeginWithBlockTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName}>\n",
             Html::begin($tag),
             "Html begin '<{$expectedTagName}>' block tag should match expected output.",
@@ -55,7 +54,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(ListsProvider::class, 'listTags')]
     public function testRenderBeginWithListTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName}>\n",
             Html::begin($tag),
             "Html begin '<{$expectedTagName}>' list tag should match expected output.",
@@ -65,7 +64,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(RootProvider::class, 'rootTags')]
     public function testRenderBeginWithRootTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName}>\n",
             Html::begin($tag),
             "Html begin '<{$expectedTagName}>' root tag should match expected output.",
@@ -75,7 +74,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(TableProvider::class, 'tableTags')]
     public function testRenderBeginWithTableTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName}>\n",
             Html::begin($tag),
             "Html begin '<{$expectedTagName}>' table tag should match expected output.",
@@ -91,15 +90,13 @@ final class HtmlTest extends TestCase
             'aria-describedby' => 'description-id',
         ];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div aria-label="Main navigation" aria-hidden="false" aria-describedby="description-id">
             Accessible content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with ARIA attributes should match expected output.",
         );
     }
@@ -153,27 +150,23 @@ final class HtmlTest extends TestCase
         $content = '<span>Test Content</span>';
         $attributes = ['class' => 'test-class'];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="test-class">
             <span>Test Content</span>
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with content and attributes should match expected output.",
         );
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="test-class">
             &lt;span&gt;Test Content&lt;/span&gt;
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes, true),
-            ),
+            Html::element(Block::DIV, $content, $attributes, true),
             "Html element '<div>' with encoded content and attributes should match expected output.",
         );
     }
@@ -182,14 +175,12 @@ final class HtmlTest extends TestCase
     {
         $attributes = ['class' => 'empty-content'];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="empty-content">
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, '', $attributes),
-            ),
+            Html::element(Block::DIV, '', $attributes),
             "Html element '<div>' with empty content and attributes should match expected output.",
         );
     }
@@ -236,15 +227,13 @@ final class HtmlTest extends TestCase
             ],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="class-1 class-2" data-id="123" data-name="test">
             content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with complex attribute structures should match expected output.",
         );
     }
@@ -253,15 +242,13 @@ final class HtmlTest extends TestCase
     {
         $content = 'content';
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div>
             content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, []),
-            ),
+            Html::element(Block::DIV, $content, []),
             "Html element '<div>' with content and empty attributes array should match expected output.",
         );
     }
@@ -299,17 +286,15 @@ final class HtmlTest extends TestCase
         $content = '<mark>inline</mark>';
         $attributes = ['id' => 'inline'];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span id="inline"><mark>inline</mark></span>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Inline::SPAN, $content, $attributes),
-            ),
+            Html::element(Inline::SPAN, $content, $attributes),
             "Html element '<span>' with content and attributes should match expected output.",
         );
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <span id="inline">&lt;mark&gt;inline&lt;/mark&gt;</span>
             HTML,
@@ -332,11 +317,9 @@ final class HtmlTest extends TestCase
         </div>
         HTML;
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with large attribute value should match expected output.",
         );
     }
@@ -349,15 +332,13 @@ final class HtmlTest extends TestCase
             'class' => 'test-class',
         ];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div class="test-class">
             content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with null attribute value should match expected output.",
         );
     }
@@ -370,15 +351,13 @@ final class HtmlTest extends TestCase
             'data-info' => 'Value with & ampersand',
         ];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <div title="Test &quot;quoted&quot; value" data-info="Value with &amp; ampersand">
             content
             </div>
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Block::DIV, $content, $attributes),
-            ),
+            Html::element(Block::DIV, $content, $attributes),
             "Html element '<div>' with special characters in attributes should match expected output.",
         );
     }
@@ -390,13 +369,11 @@ final class HtmlTest extends TestCase
             'data' => ['role' => 'presentation'],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             <<<HTML
             <img class="void" data-role="presentation">
             HTML,
-            LineEndingNormalizer::normalize(
-                Html::element(Voids::IMG, '', $attributes),
-            ),
+            Html::element(Voids::IMG, '', $attributes),
             "Html element '<img>' void tag with attributes should match expected output.",
         );
     }
@@ -404,7 +381,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(BlockProvider::class, 'blockTags')]
     public function testRenderEndWithBlockTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "\n</{$expectedTagName}>",
             Html::end($tag),
             "Html end '</{$expectedTagName}>' block tag should match expected output.",
@@ -414,7 +391,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(ListsProvider::class, 'listTags')]
     public function testRenderEndWithListTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "\n</{$expectedTagName}>",
             Html::end($tag),
             "Html end '</{$expectedTagName}>' list tag should match expected output.",
@@ -424,7 +401,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(RootProvider::class, 'rootTags')]
     public function testRenderEndWithRootTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "\n</{$expectedTagName}>",
             Html::end($tag),
             "Html end '</{$expectedTagName}>' root tag should match expected output.",
@@ -434,7 +411,7 @@ final class HtmlTest extends TestCase
     #[DataProviderExternal(TableProvider::class, 'tableTags')]
     public function testRenderEndWithTableTag(BlockInterface $tag, string $expectedTagName): void
     {
-        self::assertEquals(
+        self::assertSame(
             "\n</{$expectedTagName}>",
             Html::end($tag),
             "Html end '</{$expectedTagName}>' table tag should match expected output.",
@@ -447,12 +424,12 @@ final class HtmlTest extends TestCase
         $content = '<mark>inline</mark>';
         $attributes = ['id' => 'inline'];
 
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName} id=\"inline\">{$content}</{$expectedTagName}>",
             Html::inline($tag, $content, $attributes),
             "Html inline '<{$expectedTagName}>' tag without encoding should match expected output.",
         );
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName} id=\"inline\">&lt;mark&gt;inline&lt;/mark&gt;</{$expectedTagName}>",
             Html::inline($tag, $content, $attributes, true),
             "Html inline '<{$expectedTagName}>' tag with encoding should match expected output.",
@@ -467,7 +444,7 @@ final class HtmlTest extends TestCase
             'data' => ['role' => 'presentation'],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             "<{$expectedTagName} class=\"void\" data-role=\"presentation\">",
             Html::void($tag, $attributes),
             "Html void '<{$expectedTagName}>' tag should match expected output.",


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
