### PR TITLE
fix(element): Add `afterRun()` method to clean up excessive newlines in `BaseBlock` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bug #67: Update condition for `aria-describedby` attribute in `BaseInput` class to accept string `true` (@terabytesoftw)
 - Bug #68: Enhance HTML output formatting by adding line breaks using `PHP_EOL` const in `BaseHtml`, `BaseBlock`, `BaseInline`, and `BaseTag` classes (@terabytesoftw)
 - Bug #69: Standardize PHPDoc headers for src and test classes and update related documentation (@terabytesoftw)
+- Bug #70: Add `afterRun()` method to clean up excessive newlines in `BaseBlock` class (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -99,7 +99,6 @@ abstract class BaseBlock extends BaseTag
         return LineBreakNormalizer::normalize(parent::afterRun($result));
     }
 
-
     /**
      * Renders the block element.
      *

--- a/src/Element/BaseBlock.php
+++ b/src/Element/BaseBlock.php
@@ -27,6 +27,7 @@ use UIAwesome\Html\Attribute\Global\{
 };
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
+use UIAwesome\Html\Helper\LineBreakNormalizer;
 use UIAwesome\Html\Interop\BlockInterface;
 use UIAwesome\Html\Mixin\{HasAttributes, HasContent};
 
@@ -83,6 +84,21 @@ abstract class BaseBlock extends BaseTag
      * @return BlockInterface Tag instance for the block element.
      */
     abstract protected function getTag(): BlockInterface;
+
+    /**
+     * Cleans up the output after rendering the block element.
+     *
+     * Removes excessive consecutive newlines from the rendered output to ensure clean HTML structure.
+     *
+     * @param string $result Rendered HTML output.
+     *
+     * @return string Cleaned HTML output with excessive newlines removed.
+     */
+    protected function afterRun(string $result): string
+    {
+        return LineBreakNormalizer::normalize(parent::afterRun($result));
+    }
+
 
     /**
      * Renders the block element.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
