### PR TITLE
feat(element): Add `ariaDescribedBySuffix` property and method to customize `aria-describedby` suffix in `BaseInput` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bug #71: Update `ui-awesome/html-helper` to version `^0.7` and `ui-awesome/html-mixin` to version `^0.4` in `composer.json` (@terabytesoftw)
 - Bug #72: Remove usage examples from PHPDoc in multiple classes for cleaner documentation (@terabytesoftw)
 - Bug #73: Update last modified from `ui-awesome/html-attribute` in related classes (@terabytesoftw)
+- Enh #74: Add `ariaDescribedBySuffix` property and method to customize `aria-describedby` suffix in `BaseInput` class (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -64,6 +64,8 @@ abstract class BaseInput extends BaseTag
 
     /**
      * Suffix appended to the element `id` when `aria-describedby` is set to `true`.
+     *
+     * An empty string falls back to `'-help'` during rendering.
      */
     protected string $ariaDescribedBySuffix = '';
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -119,8 +119,10 @@ abstract class BaseInput extends BaseTag
         $id = $this->getAttribute('id', null);
         $ariaDescribedBy = $this->getAttribute('aria-describedby', null);
 
+        $ariaDescribedBySuffix = $this->ariaDescribedBySuffix === '' ? '-help' : $this->ariaDescribedBySuffix;
+
         if ($ariaDescribedBy === true || $ariaDescribedBy === 'true') {
-            $attributes['aria-describedby'] = $id !== null ? "{$id}{$this->ariaDescribedBySuffix}" : null;
+            $attributes['aria-describedby'] = $id !== null ? "{$id}{$ariaDescribedBySuffix}" : null;
         }
 
         $tokenTemplateValues = [

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -65,7 +65,7 @@ abstract class BaseInput extends BaseTag
     /**
      * Suffix appended to the element `id` when `aria-describedby` is set to `true`.
      */
-    protected string $ariaDescribedBySuffix = '-help';
+    protected string $ariaDescribedBySuffix = '';
 
     /**
      * Returns the tag instance representing the void element.

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -24,7 +24,7 @@ use UIAwesome\Html\Attribute\Global\{
 };
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Html;
-use UIAwesome\Html\Helper\{Naming, Template};
+use UIAwesome\Html\Helper\Template;
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UIAwesome\Html\Mixin\{HasAttributes, HasPrefixCollection, HasSuffixCollection, HasTemplate};
 
@@ -63,6 +63,11 @@ abstract class BaseInput extends BaseTag
     use HasType;
 
     /**
+     * Suffix appended to the element `id` when `aria-describedby` is set to `true`.
+     */
+    protected string $ariaDescribedBySuffix = '-help';
+
+    /**
      * Returns the tag instance representing the void element.
      *
      * @return VoidInterface Tag instance for the void element.
@@ -76,6 +81,21 @@ abstract class BaseInput extends BaseTag
      * ```
      */
     abstract protected function getTag(): VoidInterface;
+
+    /**
+     * Sets the suffix appended to the element `id` when `aria-describedby` is set to `true`.
+     *
+     * @param string $value Suffix to append to the element `id` for `aria-describedby`. Defaults to `'-help'`.
+     *
+     * @return static New instance with the updated `ariaDescribedBySuffix` value.
+     */
+    public function ariaDescribedBySuffix(string $value): static
+    {
+        $new = clone $this;
+        $new->ariaDescribedBySuffix = $value;
+
+        return $new;
+    }
 
     /**
      * Builds input output from content and template tokens.
@@ -100,7 +120,7 @@ abstract class BaseInput extends BaseTag
         $ariaDescribedBy = $this->getAttribute('aria-describedby', null);
 
         if ($ariaDescribedBy === true || $ariaDescribedBy === 'true') {
-            $attributes['aria-describedby'] = $id !== null ? "{$id}-help" : null;
+            $attributes['aria-describedby'] = $id !== null ? "{$id}{$this->ariaDescribedBySuffix}" : null;
         }
 
         $tokenTemplateValues = [
@@ -127,10 +147,7 @@ abstract class BaseInput extends BaseTag
      */
     protected function loadDefault(): array
     {
-        $shortClassName = Naming::getShortNameClass(static::class, false, true);
-
         return [
-            'id' => [Naming::generateId("$shortClassName-")],
             'template' => ["{prefix}\n{tag}\n{suffix}"],
         ];
     }

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Core\Tests\Element;
 
+use InvalidArgumentException;
 use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, Language, Role, Translate};
+use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, Event, GlobalAttribute, Language, Role, Translate};
 use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Core\Tests\Support\Stub\{DefaultProvider, TagInput, TagInputWithTokenValues};
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Interop\{Block, Inline, Voids};
 
 /**
@@ -884,5 +887,72 @@ final class TagInputTest extends TestCase
             $tag->getDefaults($tag),
             'Failed asserting that getting defaults returns an empty array when no defaults are set.',
         );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $tagInput = TagInput::tag();
+
+        self::assertNotSame(
+            $tagInput,
+            $tagInput->ariaDescribedBySuffix(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DIR->value,
+                implode("', '", Enum::normalizeArray(Direction::cases())),
+            ),
+        );
+
+        TagInput::tag()->dir('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::LANG->value,
+                implode("', '", Enum::normalizeArray(Language::cases())),
+            ),
+        );
+
+        TagInput::tag()->lang('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::ROLE->value,
+                implode("', '", Enum::normalizeArray(Role::cases())),
+            ),
+        );
+
+        TagInput::tag()->role('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::TRANSLATE->value,
+                implode("', '", Enum::normalizeArray(Translate::cases())),
+            ),
+        );
+
+        TagInput::tag()->translate('invalid-value');
     }
 }

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -282,7 +282,7 @@ final class TagInputTest extends TestCase
                 ->ariaDescribedBySuffix('')
                 ->id('taginput')
                 ->render(),
-            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value.",
+            "Failed asserting that an empty 'ariaDescribedBySuffix()' falls back to the default '-help' suffix.",
         );
     }
 

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -271,7 +271,7 @@ final class TagInputTest extends TestCase
         );
     }
 
-    public function testRenderWithAriaDescribedBySuffixAndEmptySuffix(): void
+    public function testRenderWithAriaDescribedBySuffixAndEmptySuffixUsesDefault(): void
     {
         self::assertSame(
             <<<HTML

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -17,6 +17,7 @@ use UIAwesome\Html\Interop\{Block, Inline, Voids};
  *
  * Test coverage.
  * - Ensures `aria-describedby` derives from `id` when set to `true` and is omitted when `id` is `null`.
+ * - Ensures `ariaDescribedBySuffix()` customizes the suffix appended to `id` for `aria-describedby`.
  * - Ensures default providers and global defaults apply expected attributes, with user overrides preserved.
  * - Verifies input tags render expected HTML for representative global and input-specific attributes.
  * - Verifies prefix and suffix content renders with block, inline, and void wrapper tags.
@@ -32,11 +33,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" accesskey="k">
+            <input accesskey="value">
             HTML,
             TagInput::tag()
-                ->accesskey('k')
-                ->id('taginput')
+                ->accesskey('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
         );
@@ -46,11 +46,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" aria-pressed="true">
+            <input aria-label="value">
             HTML,
             TagInput::tag()
-                ->addAriaAttribute('pressed', true)
-                ->id('taginput')
+                ->addAriaAttribute('label', 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
         );
@@ -60,11 +59,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" aria-pressed="true">
+            <input aria-label="value">
             HTML,
             TagInput::tag()
-                ->addAriaAttribute(Aria::PRESSED, true)
-                ->id('taginput')
+                ->addAriaAttribute(Aria::LABEL, 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
         );
@@ -74,11 +72,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" aria-describedby="custom-help">
+            <input aria-describedby="value">
             HTML,
             TagInput::tag()
-                ->addAriaAttribute('describedby', 'custom-help')
-                ->id('taginput')
+                ->addAriaAttribute('describedby', 'value')
                 ->render(),
             "Failed asserting that an explicit 'aria-describedby' string value is preserved.",
         );
@@ -175,11 +172,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" data-value="value">
+            <input data-value="value">
             HTML,
             TagInput::tag()
                 ->addDataAttribute('value', 'value')
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
         );
@@ -189,11 +185,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" data-value="value">
+            <input data-value="value">
             HTML,
             TagInput::tag()
                 ->addDataAttribute(Data::VALUE, 'value')
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
         );
@@ -203,11 +198,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" onclick="handleClick()">
+            <input onclick="handleClick()">
             HTML,
             TagInput::tag()
                 ->addEvent(Event::CLICK, 'handleClick()')
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
@@ -217,17 +211,15 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" aria-label="Close" aria-hidden="false" aria-controls="modal-1">
+            <input aria-controls="value" aria-label="value">
             HTML,
             TagInput::tag()
                 ->ariaAttributes(
                     [
-                        'label' => 'Close',
-                        'hidden' => false,
-                        'controls' => static fn(): string => 'modal-1',
+                        'controls' => 'value',
+                        'label' => 'value',
                     ],
                 )
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
         );
@@ -261,15 +253,45 @@ final class TagInputTest extends TestCase
         );
     }
 
+    public function testRenderWithAriaDescribedBySuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="taginput" aria-describedby="taginput-hint">
+            HTML,
+            TagInput::tag()
+                ->addAriaAttribute('describedby', true)
+                ->ariaDescribedBySuffix('-hint')
+                ->id('taginput')
+                ->render(),
+            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value.",
+        );
+    }
+
+    public function testRenderWithAriaDescribedBySuffixAndIdNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input>
+            HTML,
+            TagInput::tag()
+                ->addAriaAttribute('describedby', true)
+                ->ariaDescribedBySuffix('-hint')
+                ->id(null)
+                ->render(),
+            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value and 'id' "
+            . "is 'null'.",
+        );
+    }
+
     public function testRenderWithAttributes(): void
     {
         self::assertSame(
             <<<HTML
-            <input class="value" id="taginput">
+            <input class="value">
             HTML,
             TagInput::tag()
                 ->attributes(['class' => 'value'])
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
         );
@@ -307,11 +329,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input class="value" id="taginput">
+            <input class="value">
             HTML,
             TagInput::tag()
                 ->class('value')
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
         );
@@ -321,11 +342,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput">
+            <input>
             <span class="custom-token">Custom content from token</span>
             HTML,
             TagInputWithTokenValues::tag()
-                ->id('taginput')
                 ->template("{tag}\n{custom}")
                 ->tokenValues(['{custom}' => '<span class="custom-token">Custom content from token</span>'])
                 ->render(),
@@ -337,11 +357,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" data-value="test-value">
+            <input data-value="test-value">
             HTML,
             TagInput::tag()
                 ->dataAttributes(['value' => 'test-value'])
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
         );
@@ -351,11 +370,9 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input class="default-class" id="taginput" title="default-title">
+            <input class="default-class" title="default-title">
             HTML,
-            TagInput::tag(['class' => 'default-class', 'title' => 'default-title'])
-                ->id('taginput')
-                ->render(),
+            TagInput::tag(['class' => 'default-class', 'title' => 'default-title'])->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }
@@ -364,11 +381,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input class="default-provider" id="taginput">
+            <input class="default-provider">
             HTML,
             TagInput::tag()
                 ->addDefaultProvider(DefaultProvider::class)
-                ->id('taginput')
                 ->render(),
             'Failed asserting that default provider is applied correctly.',
         );
@@ -380,9 +396,7 @@ final class TagInputTest extends TestCase
             <<<HTML
             <input>
             HTML,
-            TagInput::tag()
-                ->id(null)
-                ->render(),
+            TagInput::tag()->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
@@ -391,11 +405,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" dir="rtl">
+            <input dir="rtl">
             HTML,
             TagInput::tag()
                 ->dir('rtl')
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
         );
@@ -405,11 +418,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" dir="ltr">
+            <input dir="ltr">
             HTML,
             TagInput::tag()
                 ->dir(Direction::LTR)
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute using enum.",
         );
@@ -419,11 +431,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" disabled>
+            <input disabled>
             HTML,
             TagInput::tag()
                 ->disabled(true)
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'disabled' attribute.",
         );
@@ -433,11 +444,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" onchange="handleChange()">
+            <input onchange="handleChange()">
             HTML,
             TagInput::tag()
                 ->events(['change' => 'handleChange()'])
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'events()' method.",
         );
@@ -447,25 +457,12 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" form="signup-form">
+            <input form="value">
             HTML,
             TagInput::tag()
-                ->form('signup-form')
-                ->id('taginput')
+                ->form('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'form' attribute.",
-        );
-    }
-
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = TagInput::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^taginput-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
         );
     }
 
@@ -480,11 +477,9 @@ final class TagInputTest extends TestCase
 
         self::assertSame(
             <<<HTML
-            <input class="from-global" id="taginput">
+            <input class="from-global">
             HTML,
-            TagInput::tag()
-                ->id('taginput')
-                ->render(),
+            TagInput::tag()->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
@@ -498,11 +493,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" hidden>
+            <input hidden>
             HTML,
             TagInput::tag()
                 ->hidden(true)
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
         );
@@ -512,10 +506,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput">
+            <input id="value">
             HTML,
             TagInput::tag()
-                ->id('taginput')
+                ->id('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'id' attribute.",
         );
@@ -525,11 +519,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" lang="es">
+            <input lang="en">
             HTML,
             TagInput::tag()
-                ->id('taginput')
-                ->lang('es')
+                ->lang('en')
                 ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
         );
@@ -539,11 +532,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" lang="es">
+            <input lang="en">
             HTML,
             TagInput::tag()
-                ->id('taginput')
-                ->lang(Language::SPANISH)
+                ->lang(Language::ENGLISH)
                 ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute using enum.",
         );
@@ -559,19 +551,6 @@ final class TagInputTest extends TestCase
             $defaults,
             "Failed asserting that 'loadDefault()' method returns an array.",
         );
-        self::assertIsArray(
-            $defaults['id'] ?? null,
-            "Failed asserting that default 'id' is an array in 'loadDefault()' method.",
-        );
-        self::assertIsString(
-            $defaults['id'][0] ?? null,
-            "Failed asserting that default 'id' template is a string in 'loadDefault()' method.",
-        );
-        self::assertStringContainsString(
-            'taginput-',
-            $defaults['id'][0],
-            "Failed asserting that default 'id' is generated correctly in 'loadDefault()' method.",
-        );
         self::assertSame(
             ["{prefix}\n{tag}\n{suffix}"],
             $defaults['template'] ?? [],
@@ -583,11 +562,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" name="username">
+            <input name="value">
             HTML,
             TagInput::tag()
-                ->id('taginput')
-                ->name('username')
+                ->name('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'name' attribute.",
         );
@@ -598,11 +576,10 @@ final class TagInputTest extends TestCase
         self::assertSame(
             <<<HTML
             <strong>Prefix</strong>
-            <input id="taginput">
+            <input>
             <em>Suffix</em>
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->prefix('Prefix')
                 ->prefixTag(Inline::STRONG)
                 ->suffix('Suffix')
@@ -617,11 +594,10 @@ final class TagInputTest extends TestCase
         self::assertSame(
             <<<HTML
             Prefix content
-            <input class="test" id="taginput">
+            <input class="value">
             HTML,
             TagInput::tag()
-                ->class('test')
-                ->id('taginput')
+                ->class('value')
                 ->prefix('Prefix content')
                 ->render(),
             "Failed asserting that element renders correctly with 'prefix()' method.",
@@ -635,10 +611,9 @@ final class TagInputTest extends TestCase
             <div class="prefix-class" id="prefix-id">
             Prefix content
             </div>
-            <input id="taginput">
+            <input>
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->prefix('Prefix content')
                 ->prefixAttributes(['id' => 'prefix-id'])
                 ->prefixClass('prefix-class')
@@ -653,10 +628,9 @@ final class TagInputTest extends TestCase
         self::assertSame(
             <<<HTML
             <strong class="prefix-class" id="prefix-id">Prefix content</strong>
-            <input id="taginput">
+            <input>
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->prefix('Prefix content')
                 ->prefixAttributes(['id' => 'prefix-id'])
                 ->prefixClass('prefix-class')
@@ -670,10 +644,9 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" role="button">
+            <input role="button">
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->role('button')
                 ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
@@ -684,10 +657,9 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" role="button">
+            <input role="button">
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->role(Role::BUTTON)
                 ->render(),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
@@ -698,11 +670,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" style='test-value'>
+            <input style='value'>
             HTML,
             TagInput::tag()
-                ->id('taginput')
-                ->style('test-value')
+                ->style('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",
         );
@@ -712,12 +683,11 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input class="test" id="taginput">
+            <input class="value">
             Suffix content
             HTML,
             TagInput::tag()
-                ->class('test')
-                ->id('taginput')
+                ->class('value')
                 ->suffix('Suffix content')
                 ->render(),
             "Failed asserting that element renders correctly with 'suffix()' method.",
@@ -728,13 +698,12 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput">
+            <input>
             <div class="suffix-class" id="suffix-id">
             Suffix content
             </div>
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->suffix('Suffix content')
                 ->suffixAttributes(['id' => 'suffix-id'])
                 ->suffixClass('suffix-class')
@@ -748,11 +717,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput">
+            <input>
             <strong class="suffix-class" id="suffix-id">Suffix content</strong>
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->suffix('Suffix content')
                 ->suffixAttributes(['id' => 'suffix-id'])
                 ->suffixClass('suffix-class')
@@ -767,11 +735,10 @@ final class TagInputTest extends TestCase
         self::assertSame(
             <<<HTML
             Prefix content
-            <input id="taginput">
+            <input>
             Suffix content
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->template('')
                 ->prefix('Prefix content')
                 ->suffix('Suffix content')
@@ -784,11 +751,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" title="test-value">
+            <input title="value">
             HTML,
             TagInput::tag()
-                ->id('taginput')
-                ->title('test-value')
+                ->title('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
@@ -809,12 +775,11 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" translate="no">
+            <input translate="no">
             HTML,
             TagInput::tag()
-                    ->id('taginput')
-                    ->translate('no')
-                    ->render(),
+                ->translate('no')
+                ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
         );
     }
@@ -823,11 +788,10 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" translate="yes">
+            <input translate="yes">
             HTML,
             TagInput::tag()
                 ->translate(Translate::YES)
-                ->id('taginput')
                 ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
         );
@@ -837,10 +801,9 @@ final class TagInputTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="taginput" type="text">
+            <input type="text">
             HTML,
             TagInput::tag()
-                ->id('taginput')
                 ->type('text')
                 ->render(),
             "Failed asserting that element renders correctly with 'type' attribute.",
@@ -861,9 +824,9 @@ final class TagInputTest extends TestCase
 
         self::assertSame(
             <<<HTML
-            <input class="from-global" id="id-user">
+            <input class="from-global" id="value">
             HTML,
-            TagInput::tag(['id' => 'id-user'])->render(),
+            TagInput::tag(['id' => 'value'])->render(),
             'Failed asserting that user-defined attributes override global defaults correctly.',
         );
 
@@ -881,7 +844,6 @@ final class TagInputTest extends TestCase
             <input>
             HTML,
             TagInput::tag()
-                ->id(null)
                 ->prefixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
                 ->prefixTag(Voids::IMG)
                 ->render(),
@@ -897,7 +859,6 @@ final class TagInputTest extends TestCase
             <img src="icon.svg" alt="Icon">
             HTML,
             TagInput::tag()
-                ->id(null)
                 ->suffixAttributes(['src' => 'icon.svg', 'alt' => 'Icon'])
                 ->suffixTag(Voids::IMG)
                 ->render(),

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -271,6 +271,21 @@ final class TagInputTest extends TestCase
         );
     }
 
+    public function testRenderWithAriaDescribedBySuffixAndEmptySuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="taginput" aria-describedby="taginput-help">
+            HTML,
+            TagInput::tag()
+                ->addAriaAttribute('describedby', true)
+                ->ariaDescribedBySuffix('')
+                ->id('taginput')
+                ->render(),
+            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value.",
+        );
+    }
+
     public function testRenderWithAriaDescribedBySuffixAndIdNull(): void
     {
         self::assertSame(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
