### PR TITLE
fix(element): Remove automatic `aria-describedby` handling and suffix customization from `BaseInput` and delete related tests from `TagInputTest`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enh #74: Add `ariaDescribedBySuffix` property and method to customize `aria-describedby` suffix in `BaseInput` class (@terabytesoftw)
 - Fix #75: Correct `ariaDescribedBySuffix` formatting in `BaseInput` class and update test case in `TagInputTest` class (@terabytesoftw)
 - Enh #76: Align architecture with `ui-awesome/html-contracts` by migrating element tag type hints to `BackedEnum`, implementing contracts across base elements, moving `begin()`/`end()` lifecycle flow from `BaseTag` to `BaseBlock`, and making `BaseHtml::element()` a generic renderer while inline and void selection remains in element-specific classes (@terabytesoftw)
+- Bug #77: Remove automatic `aria-describedby` handling and suffix customization from `BaseInput` and delete related tests from `TagInputTest` (@terabytesoftw)
 
 ## 0.5.2 January 28, 2026
 

--- a/src/Element/BaseInput.php
+++ b/src/Element/BaseInput.php
@@ -65,13 +65,6 @@ abstract class BaseInput extends BaseTag implements FormControlInterface
     use HasType;
 
     /**
-     * Suffix appended to the element `id` when `aria-describedby` is set to `true`.
-     *
-     * An empty string falls back to `'-help'` during rendering.
-     */
-    protected string $ariaDescribedBySuffix = '';
-
-    /**
      * Returns the tag instance representing the void element.
      *
      * @return BackedEnum Tag instance for the void element.
@@ -85,21 +78,6 @@ abstract class BaseInput extends BaseTag implements FormControlInterface
      * ```
      */
     abstract protected function getTag(): BackedEnum;
-
-    /**
-     * Sets the suffix appended to the element `id` when `aria-describedby` is set to `true`.
-     *
-     * @param string $value Suffix to append to the element `id` for `aria-describedby`. Defaults to `'-help'`.
-     *
-     * @return static New instance with the updated `ariaDescribedBySuffix` value.
-     */
-    public function ariaDescribedBySuffix(string $value): static
-    {
-        $new = clone $this;
-        $new->ariaDescribedBySuffix = $value;
-
-        return $new;
-    }
 
     /**
      * Builds input output from content and template tokens.
@@ -118,16 +96,6 @@ abstract class BaseInput extends BaseTag implements FormControlInterface
     protected function buildElement(string|Stringable $content = '', array $tokenValues = []): string
     {
         $attributes = $this->getAttributes();
-
-        /** @phpstan-var string|null $id */
-        $id = $this->getAttribute('id', null);
-        $ariaDescribedBy = $this->getAttribute('aria-describedby', null);
-
-        $ariaDescribedBySuffix = $this->ariaDescribedBySuffix === '' ? '-help' : "-{$this->ariaDescribedBySuffix}";
-
-        if ($ariaDescribedBy === true || $ariaDescribedBy === 'true') {
-            $attributes['aria-describedby'] = $id !== null ? "{$id}{$ariaDescribedBySuffix}" : null;
-        }
 
         $tokenTemplateValues = [
             '{prefix}' => $this->renderTag($this->getPrefixTag(), $this->getPrefix(), $this->getPrefixAttributes()),

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -19,8 +19,6 @@ use UIAwesome\Html\Interop\{Block, Inline, Voids};
  * Unit tests for the {@see TagInput} class.
  *
  * Test coverage.
- * - Ensures `aria-describedby` derives from `id` when set to `true` and is omitted when `id` is `null`.
- * - Ensures `ariaDescribedBySuffix()` customizes the suffix appended to `id` for `aria-describedby`.
  * - Ensures default providers and global defaults apply expected attributes, with user overrides preserved.
  * - Verifies input tags render expected HTML for representative global and input-specific attributes.
  * - Verifies prefix and suffix content renders with block, inline, and void wrapper tags.
@@ -84,93 +82,6 @@ final class TagInputTest extends TestCase
         );
     }
 
-    public function testRenderWithAddAriaDescribedByTrueBooleanValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
-            . "'true'.",
-        );
-    }
-
-    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndIdNull(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input>
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->id(null)
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
-            . "'true' and 'id' is 'null'.",
-        );
-    }
-
-    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndPrefixSuffix(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <span>Prefix</span>
-            <input id="taginput" aria-describedby="taginput-help">
-            <span>Suffix</span>
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->id('taginput')
-                ->prefix('Prefix')
-                ->prefixTag(Inline::SPAN)
-                ->suffix('Suffix')
-                ->suffixTag(Inline::SPAN)
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
-            . "'true' and prefix/suffix.",
-        );
-    }
-
-    public function testRenderWithAddAriaDescribedByTrueBooleanValueString(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', 'true')
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
-            . "'true'.",
-        );
-    }
-
-    public function testRenderWithAddAriaDescribedByTrueStringValueAndPrefixSuffix(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <span>Prefix</span>
-            <input id="taginput" aria-describedby="taginput-help">
-            <span>Suffix</span>
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', 'true')
-                ->id('taginput')
-                ->prefix('Prefix')
-                ->prefixTag(Inline::SPAN)
-                ->suffix('Suffix')
-                ->suffixTag(Inline::SPAN)
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
-            . "'true' and prefix/suffix.",
-        );
-    }
-
     public function testRenderWithAddDataAttribute(): void
     {
         self::assertSame(
@@ -228,80 +139,6 @@ final class TagInputTest extends TestCase
         );
     }
 
-    public function testRenderWithAriaAttributesAndAriaDescribedByTrueBooleanValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->ariaAttributes(['describedby' => true])
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true.",
-        );
-    }
-
-    public function testRenderWithAriaAttributesAndAriaDescribedByTrueStringValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->ariaAttributes(['describedby' => 'true'])
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true.",
-        );
-    }
-
-    public function testRenderWithAriaDescribedBySuffix(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-hint">
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->ariaDescribedBySuffix('hint')
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value.",
-        );
-    }
-
-    public function testRenderWithAriaDescribedBySuffixAndEmptySuffixUsesDefault(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->ariaDescribedBySuffix('')
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that an empty 'ariaDescribedBySuffix()' falls back to the default '-help' suffix.",
-        );
-    }
-
-    public function testRenderWithAriaDescribedBySuffixAndIdNull(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input>
-            HTML,
-            TagInput::tag()
-                ->addAriaAttribute('describedby', true)
-                ->ariaDescribedBySuffix('-hint')
-                ->id(null)
-                ->render(),
-            "Failed asserting that element renders correctly with a custom 'ariaDescribedBySuffix()' value and 'id' "
-            . "is 'null'.",
-        );
-    }
-
     public function testRenderWithAttributes(): void
     {
         self::assertSame(
@@ -312,34 +149,6 @@ final class TagInputTest extends TestCase
                 ->attributes(['class' => 'value'])
                 ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
-        );
-    }
-
-    public function testRenderWithAttributesAndAriaDescribedByTrueBooleanValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->attributes(['aria-describedby' => true])
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true.",
-        );
-    }
-
-    public function testRenderWithAttributesAndAriaDescribedByTrueStringValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="taginput" aria-describedby="taginput-help">
-            HTML,
-            TagInput::tag()
-                ->attributes(['aria-describedby' => 'true'])
-                ->id('taginput')
-                ->render(),
-            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to true.",
         );
     }
 
@@ -910,7 +719,7 @@ final class TagInputTest extends TestCase
 
         self::assertNotSame(
             $tagInput,
-            $tagInput->ariaDescribedBySuffix(''),
+            $tagInput->id('value'),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }

--- a/tests/Element/TagInputTest.php
+++ b/tests/Element/TagInputTest.php
@@ -713,17 +713,6 @@ final class TagInputTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingAttribute(): void
-    {
-        $tagInput = TagInput::tag();
-
-        self::assertNotSame(
-            $tagInput,
-            $tagInput->id('value'),
-            'Should return a new instance when setting the attribute, ensuring immutability.',
-        );
-    }
-
     public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
